### PR TITLE
fix: use npm install to resolve Linux rollup binary on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: site/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
Windows-generated package-lock.json omits the Linux optional rollup binary, causing CI to fail. Switching to npm install lets npm resolve the correct platform deps on the runner.