### PR TITLE
fix: move Calendly CSS/script to head (valid HTML, avoid FOUC)

### DIFF
--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -28,6 +28,7 @@ const { title, description = 'Personal website' } = Astro.props;
       rel="stylesheet"
     />
     <title>{title}</title>
+    <slot name="head" />
   </head>
   <body class="min-h-screen bg-stone-50 text-stone-900">
     <Nav />

--- a/site/src/pages/contact.astro
+++ b/site/src/pages/contact.astro
@@ -4,6 +4,18 @@ import settings from '../content/settings/main.json';
 ---
 
 <Layout title={`Contact — ${settings.name}`}>
+  <Fragment slot="head">
+    <!-- Calendly inline widget assets — in head for valid HTML -->
+    <link
+      href="https://assets.calendly.com/assets/external/widget.css"
+      rel="stylesheet"
+    />
+    <script
+      type="text/javascript"
+      src="https://assets.calendly.com/assets/external/widget.js"
+      async
+    />
+  </Fragment>
   <section class="mx-auto max-w-5xl px-6 pb-24 pt-40">
     <div class="max-w-xl">
       <p
@@ -19,23 +31,13 @@ import settings from '../content/settings/main.json';
         I'll get back to you.
       </p>
 
-      <!-- Calendly inline widget begin -->
-      <!-- REPLACE: swap PLACEHOLDER with Agreni's real Calendly username before going live -->
-      <link
-        href="https://assets.calendly.com/assets/external/widget.css"
-        rel="stylesheet"
-      />
+      <!-- Calendly inline widget — REPLACE PLACEHOLDER with Agreni's Calendly username -->
       <div
         class="calendly-inline-widget overflow-hidden rounded-2xl border border-stone-100"
         data-url="https://calendly.com/PLACEHOLDER/30min"
         style="min-width:320px;height:700px;"
       >
       </div>
-      <script
-        type="text/javascript"
-        src="https://assets.calendly.com/assets/external/widget.js"
-        async></script>
-      <!-- Calendly inline widget end -->
 
       {
         settings.email && (

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -18,6 +18,18 @@ const featured = projects
   title={`${settings.name} — ${settings.tagline}`}
   description={settings.bio}
 >
+  <Fragment slot="head">
+    <!-- Calendly popup assets — in head for valid HTML -->
+    <link
+      href="https://assets.calendly.com/assets/external/widget.css"
+      rel="stylesheet"
+    />
+    <script
+      type="text/javascript"
+      src="https://assets.calendly.com/assets/external/widget.js"
+      async
+    />
+  </Fragment>
   <!-- Hero -->
   <section
     class="mx-auto flex min-h-screen max-w-5xl flex-col justify-center px-6 pb-16 pt-24"
@@ -54,15 +66,6 @@ const featured = projects
         Book a conversation
       </a>
     </div>
-    <!-- Calendly assets -->
-    <link
-      href="https://assets.calendly.com/assets/external/widget.css"
-      rel="stylesheet"
-    />
-    <script
-      type="text/javascript"
-      src="https://assets.calendly.com/assets/external/widget.js"
-      async></script>
   </section>
 
   <!-- Featured Work -->


### PR DESCRIPTION
Moves Calendly assets from body to head via Layout head slot. Valid HTML, avoids FOUC. Audit ticket 1.

Made with [Cursor](https://cursor.com)