### PR TITLE
feat: add Open Graph and social meta tags

### DIFF
--- a/site/public/og-default.svg
+++ b/site/public/og-default.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#fafaf9"/>
+  <rect x="60" y="60" width="1080" height="510" rx="16" fill="#1c1917" stroke="#e7e5e4" stroke-width="2"/>
+  <text x="600" y="320" font-family="Georgia, serif" font-size="120" font-style="italic" fill="#f5f5f4" text-anchor="middle">Agreni</text>
+  <text x="600" y="420" font-family="system-ui, sans-serif" font-size="32" fill="#a8a29e" text-anchor="middle">Creative professional</text>
+</svg>

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -5,9 +5,15 @@ import '../styles/global.css';
 interface Props {
   title: string;
   description?: string;
+  ogImage?: string;
+  ogUrl?: string;
 }
 
-const { title, description = 'Personal website' } = Astro.props;
+const { title, description = 'Personal website', ogImage, ogUrl } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const site = import.meta.env.SITE ?? 'https://rainonej.github.io';
+const canonicalUrl = ogUrl ?? `${site}${base}${Astro.url.pathname}`;
+const imageUrl = ogImage ? (ogImage.startsWith('http') ? ogImage : `${site}${base}/${ogImage.replace(/^\//, '')}`) : `${site}${base}/og-default.svg`;
 ---
 
 <!doctype html>
@@ -16,6 +22,17 @@ const { title, description = 'Personal website' } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    <!-- Open Graph -->
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={imageUrl} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:type" content="website" />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={imageUrl} />
     <link
       rel="icon"
       type="image/svg+xml"


### PR DESCRIPTION
Layout gets ogImage/ogUrl props; default og-default.svg. Audit ticket 3.

Made with [Cursor](https://cursor.com)