### PR TITLE
feat: add content.config.ts and migrate to getCollection/getEntry

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,0 +1,21 @@
+import { defineCollection } from 'astro:content';
+import { z } from 'astro/zod';
+
+const projectsSchema = z.object({
+  title: z.string(),
+  description: z.string().optional(),
+  image: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  link: z.string().optional(),
+  date: z.coerce.date(),
+  featured: z.boolean().optional(),
+});
+
+const projects = defineCollection({
+  type: 'content',
+  schema: projectsSchema,
+});
+
+export const collections = {
+  projects,
+};

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,21 +1,17 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
 import settings from '../content/settings/main.json';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const projects = await Astro.glob('../content/projects/*.md');
+const projects = await getCollection('projects');
 const featured = projects
-  .filter((p) => p.frontmatter.featured)
+  .filter((p) => p.data.featured)
   .sort(
     (a, b) =>
-      new Date(b.frontmatter.date).getTime() -
-      new Date(a.frontmatter.date).getTime()
+      new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
   )
   .slice(0, 3);
-function slugFromProject(project: (typeof projects)[number]): string {
-  const file = (project as { file?: string }).file ?? '';
-  return file.split(/[/\\]/).pop()?.replace(/\.md$/, '') ?? '';
-}
 ---
 
 <Layout
@@ -90,9 +86,8 @@ function slugFromProject(project: (typeof projects)[number]): string {
           </div>
           <div class="grid gap-10 md:grid-cols-3">
             {featured.map((project) => {
-              const p = project.frontmatter;
-              const slug = slugFromProject(project);
-              const detailUrl = `${base}/work/${slug}`;
+              const p = project.data;
+              const detailUrl = `${base}/work/${project.slug}`;
               return (
                 <a href={detailUrl} class="block">
                   <article class="group">

--- a/site/src/pages/work.astro
+++ b/site/src/pages/work.astro
@@ -1,18 +1,14 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
 import settings from '../content/settings/main.json';
 
-const projects = await Astro.glob('../content/projects/*.md');
+const projects = await getCollection('projects');
 const sorted = projects.sort(
   (a, b) =>
-    new Date(b.frontmatter.date).getTime() -
-    new Date(a.frontmatter.date).getTime()
+    new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
 );
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-function slugFromProject(project: (typeof projects)[number]): string {
-  const file = (project as { file?: string }).file ?? '';
-  return file.split(/[/\\]/).pop()?.replace(/\.md$/, '') ?? '';
-}
 ---
 
 <Layout title={`Work — ${settings.name}`}>
@@ -32,9 +28,8 @@ function slugFromProject(project: (typeof projects)[number]): string {
       ) : (
         <div class="grid gap-12 md:grid-cols-2">
           {sorted.map((project) => {
-            const p = project.frontmatter;
-            const slug = slugFromProject(project);
-            const detailUrl = `${base}/work/${slug}`;
+            const p = project.data;
+            const detailUrl = `${base}/work/${project.slug}`;
             return (
               <article class="group">
                 <a href={detailUrl} class="block">

--- a/site/src/pages/work/[slug].astro
+++ b/site/src/pages/work/[slug].astro
@@ -1,22 +1,19 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import { getCollection, render } from 'astro:content';
 import settings from '../../content/settings/main.json';
 
 export async function getStaticPaths() {
-  const projects = await Astro.glob('../../content/projects/*.md');
-  return projects.map((project) => {
-    const file = (project as { file?: string }).file ?? '';
-    const slug = file.split(/[/\\]/).pop()?.replace(/\.md$/, '') ?? '';
-    return {
-      params: { slug },
-      props: { project },
-    };
-  });
+  const projects = await getCollection('projects');
+  return projects.map((entry) => ({
+    params: { slug: entry.slug },
+    props: { entry },
+  }));
 }
 
-const { project } = Astro.props;
-const { Content } = project;
-const p = project.frontmatter;
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+const p = entry.data;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 


### PR DESCRIPTION
Add content collections: projects schema in content.config.ts; replace Astro.glob with getCollection('projects') in index and work; use getCollection + render() in work/[slug].astro. Settings remain JSON import.