### PR TITLE
fix: Decap CMS media paths and remove unused uploads dir

### DIFF
--- a/site/public/admin/config.yml
+++ b/site/public/admin/config.yml
@@ -6,8 +6,9 @@ backend:
 # uncomment the line below and reload /admin
 # local_backend: true
 
-media_folder: public/images/uploads
-public_folder: /images/uploads
+# Align with common Netlify/static CMS setup (e.g. Pages CMS)
+media_folder: public/media
+public_folder: /media
 
 # Update these after you connect Netlify:
 # site_url: https://your-site.netlify.app


### PR DESCRIPTION
Option A: set media_folder to public/media and public_folder to /media to align with common static CMS setup. No images/uploads directory existed to remove.

Made with [Cursor](https://cursor.com)