### PR TITLE
fix: align base path and docs with repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Live site: https://rainonej.github.io/profesional_site/**
 
+Base path in `site/astro.config.mjs` matches the GitHub repo name (`profesional_site`); no change needed.
+
 A personal / professional demo website built with Astro + Tailwind CSS.
 
 ## Structure


### PR DESCRIPTION
Verified via \gh repo view\: repo name is **profesional_site** (one s). \site/astro.config.mjs\ already has \ase: '/profesional_site'\. Added README note documenting the verification; no config or URL changes needed.