### PR TITLE
chore(ci): document triggers and ensure push only to main (#48)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
+# Triggers: one run per PR (on pull_request), one run on merge (push to main).
+# Push to non-main branches does not run CI. See #43, #48.
 name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Closes #48. Part of #31.

- Add comment at top of workflow: one run per PR, one run on push to main.
- Set \push.branches\ to \[main]\ so CI does not run on push to feature branches.

Made with [Cursor](https://cursor.com)