### PR TITLE
refactor(ci): use composite action for site setup (#50)

### DIFF
--- a/.github/actions/setup-site/action.yml
+++ b/.github/actions/setup-site/action.yml
@@ -1,0 +1,27 @@
+# Shared setup for site jobs: Node, npm ci, optional Rollup Linux fix.
+# Call after checkout. Use working-directory: site for run steps.
+name: 'Setup site'
+description: 'Checkout not included; run actions/checkout first. Sets up Node, npm ci, and optionally Rollup Linux binary.'
+inputs:
+  with_rollup:
+    description: 'Install Rollup Linux native binary (needed for astro check and build on Linux)'
+    required: false
+    default: 'true'
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+        cache-dependency-path: site/package-lock.json
+
+    - name: Install dependencies
+      working-directory: site
+      run: npm ci
+
+    - name: Fix Rollup optional dependency
+      if: inputs.with_rollup == 'true'
+      working-directory: site
+      run: npm install @rollup/rollup-linux-x64-gnu --no-save

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Job order: lint → astro-check & build (both need lint) → deploy (main only)
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -21,16 +22,10 @@ jobs:
           pip install yamllint
           yamllint .pages.yml site/public/admin/config.yml .github/workflows/
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup site
+        uses: ./.github/actions/setup-site
         with:
-          node-version: 20
-          cache: 'npm'
-          cache-dependency-path: site/package-lock.json
-
-      - name: Install dependencies (site)
-        working-directory: site
-        run: npm ci
+          with_rollup: false
 
       - name: Lint (ESLint, stylelint, Prettier)
         working-directory: site
@@ -39,57 +34,33 @@ jobs:
   astro-check:
     runs-on: ubuntu-latest
     needs: lint
-    defaults:
-      run:
-        working-directory: site
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup site
+        uses: ./.github/actions/setup-site
         with:
-          node-version: 20
-          cache: 'npm'
-          cache-dependency-path: site/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      # Install Rollup Linux native binary (lockfile from Windows omits it; npm/cli#4828)
-      - name: Fix Rollup optional dependency
-        run: npm install @rollup/rollup-linux-x64-gnu --no-save
+          with_rollup: true
 
       - name: Astro check
+        working-directory: site
         run: npm run check
 
   build:
     runs-on: ubuntu-latest
     needs: [lint, astro-check]
-    defaults:
-      run:
-        working-directory: site
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup site
+        uses: ./.github/actions/setup-site
         with:
-          node-version: 20
-          cache: 'npm'
-          cache-dependency-path: site/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      # Install Rollup Linux native binary (lockfile from Windows omits it; npm/cli#4828)
-      - name: Fix Rollup optional dependency
-        run: npm install @rollup/rollup-linux-x64-gnu --no-save
+          with_rollup: true
 
       - name: Build
+        working-directory: site
         run: npm run build
 
       - name: Upload artifact


### PR DESCRIPTION
Closes #50. Part of #31.

- Add \.github/actions/setup-site\: Node, npm ci, optional Rollup Linux fix.
- Use it in lint (with_rollup: false), astro-check, and build (with_rollup: true).
- Add job-order comment; remove redundant defaults and step duplication.

Made with [Cursor](https://cursor.com)