### PR TITLE
feat: establish dev/main two-branch workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,5 +11,10 @@
 - [ ] `npm run build` passes
 - [ ] Visual check in browser via `npm run dev`
 
+## Branch checklist
+
+- [ ] Target branch is `dev` (feature/fix PRs) — or `main` only if this is a release PR (`dev` → `main`)
+- [ ] Branch created from `dev`, not `main`
+
 ---
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,13 @@
-# Triggers: one run per PR (on pull_request), one run on merge (push to main).
-# Push to non-main branches does not run CI. See #43, #48.
+# Triggers: checks run on PRs into dev or main; deploy runs on push to main only.
+# Feature/fix PRs target dev. Release PRs (dev→main) trigger both checks and deploy.
+# See epic #57.
 name: CI
 
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 # Job order: lint → astro-check & build (both need lint) → deploy (main only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ All autonomous actions are sandboxed to this repository:
 - Installing global software (`npm install -g`, `pip install --user`, etc.)
 - Modifying OS or system configuration
 - Accessing SSH keys, secrets, or credentials beyond placeholders
-- Force-pushing to `main`
-- Merging PRs without `--auto` (always use `gh pr merge <number> --auto` so the merge happens after required status checks pass)
+- Force-pushing to `main` or `dev`
+- Merging PRs without `--auto` (always use `gh pr merge <number> --auto --merge` so the merge happens after required status checks pass)
 
 ---
 
@@ -58,10 +58,13 @@ professional_site/
 
 ## Git Workflow
 
-1. Feature work goes on a branch named `feat/<description>` or `fix/<description>`.
+Two-branch model: `dev` is the integration branch; `main` is production (GitHub Pages deploys from it).
+
+1. Feature work goes on a branch named `feat/<description>` or `fix/<description>`, created from `dev`.
 2. Commits use conventional format: `feat:`, `fix:`, `chore:`, `docs:`, etc.
-3. Each logical chunk of work ends with a push and a PR.
-4. `main` is the integration branch; never force-push it.
+3. Each logical chunk of work ends with a push and a PR **targeting `dev`**.
+4. When ready to release, open a PR from `dev` → `main` (release PR).
+5. Never force-push `dev` or `main`.
 
 ---
 
@@ -69,13 +72,15 @@ professional_site/
 
 - **Framework**: Astro (static-site friendly, component islands)
 - **Styling**: Tailwind CSS
-- **Deployment target**: GitHub Pages or Netlify (static export)
+- **Deployment target**: GitHub Pages (deploys from `main` only)
 
 ---
 
 ## Notes for Future Sessions
 
 - Always check existing branches before starting new work (`git branch -a`).
+- **Default integration branch is `dev`** — create feature branches from `dev`, and PRs target `dev`.
 - Prefer editing existing files over creating new ones when appropriate.
 - Keep PRs focused and small — one logical change per PR.
-- **Merge PRs with `gh pr merge <number> --auto`** so GitHub merges when lint/build pass. Do not use `gh pr merge <number> --merge`; branch protection requires status checks and will reject the merge until they pass.
+- **Merge PRs with `gh pr merge <number> --auto --merge`** so GitHub merges when CI passes. Auto-merge is enabled on this repo. Do not use `--merge` alone; branch protection blocks until checks pass.
+- `dev` → `main` release PRs are opened manually when ready to deploy to production.


### PR DESCRIPTION
Closes #58, #60, #62
Part of epic #57.

## Summary
First PR targeting `dev` — smoke test of the new workflow.

## Changes
- **CI** (`#60`): `pull_request` trigger now includes `dev` so feature PRs get checks
- **CLAUDE.md** (`#62`): Git workflow updated — feature branches from `dev`, PRs target `dev`, release PRs go `dev`→`main`; Hard Limits updated to include `dev`; auto-merge flag corrected
- **PR template** (`#62`): Branch checklist added so target branch is always intentional

## Applied via GitHub API (not in this PR)
- `dev` branch created from `main` tip, set as default branch (`#58`)
- Branch protection on `dev`: require PR + lint/astro-check/build, no force-push (`#59`)
- `astro-check` added to `main` required checks (`#59`)
- Auto-merge enabled at repo level (`#59`)

## Still open
- `#61` — Pages CMS branch config (human action: point CMS at `dev` in app.pagescms.org settings)

## Test plan
- [ ] CI runs on this PR (targeting `dev`)
- [ ] `npm run build` passes
- [ ] Auto-merge works after checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)