### PR TITLE
fix: make base path conditional for Vercel vs GitHub Pages

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,8 +1,14 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 
+// GitHub Actions sets GITHUB_ACTIONS=true. Vercel does not.
+// Base path is only needed for GitHub Pages (repo sub-path).
+const isGitHubPages = process.env.GITHUB_ACTIONS === 'true';
+
 export default defineConfig({
-  site: 'https://rainonej.github.io',
-  base: '/profesional_site',
+  site: isGitHubPages
+    ? 'https://rainonej.github.io'
+    : 'https://profesional-site.vercel.app',
+  base: isGitHubPages ? '/profesional_site' : '/',
   integrations: [tailwind()],
 });


### PR DESCRIPTION
## Problem
\`astro.config.mjs\` had \`base: '/profesional_site'\` hardcoded. On Vercel (which serves from \`/\`), this caused:
- All internal links to 404 (e.g. \`/profesional_site/work/web-redesign\` instead of \`/work/web-redesign\`)
- CSS/assets to fail to load (same prefix issue)

## Fix
Use \`process.env.GITHUB_ACTIONS === 'true'\` to detect the build environment:
- **GitHub Actions** (GitHub Pages deploy): \`base: '/profesional_site'\`
- **Vercel / local**: \`base: '/'\`

\`GITHUB_ACTIONS\` is automatically injected by GitHub Actions runners. Vercel does not set it.

## Test plan
- [ ] Vercel redeploys automatically and links work at \`profesional-site.vercel.app\`
- [ ] GitHub Pages deploy still works at \`rainonej.github.io/profesional_site/\`
- [ ] Local \`npm run dev\` works (base is \`/\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)