### PR TITLE
docs: restructure docs, update walkthrough and architecture (#23)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# Docs
+
+Documentation for the professional site project.
+
+## For Agreni (non-technical)
+
+| Doc | What it covers |
+|-----|---------------|
+| [collaborator-walkthrough.md](collaborator-walkthrough.md) | How to edit the site in Pages CMS — bio, projects, writing, testimonials, leaving notes for the dev |
+
+## For developers
+
+| Doc | What it covers |
+|-----|---------------|
+| [architecture.md](architecture.md) | Stack, repo layout, content model, data flow |
+| [ci.md](ci.md) | CI/CD pipeline, job order, deploy targets |
+| [lint.md](lint.md) | Linting tools, how to run locally, pre-commit hook |
+| [costs.md](costs.md) | Hosting and service cost breakdown |
+| [project-brief.md](project-brief.md) | Original brief — goals, audience, scope |
+
+## Project management
+
+| Doc | What it covers |
+|-----|---------------|
+| [issue-labels.md](issue-labels.md) | Label taxonomy and how to apply labels |
+| [project-management.md](project-management.md) | Workflow conventions |
+| [epic-briefs.md](epic-briefs.md) | Epic descriptions and acceptance criteria |
+| [github-project-views.md](github-project-views.md) | GitHub Projects board setup |
+
+## Reference
+
+| Doc | What it covers |
+|-----|---------------|
+| [demo-plan.md](demo-plan.md) | Original demo plan and milestone map |
+| [audit-report.html](audit-report.html) | Codebase audit (open in browser) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,81 +4,86 @@
 
 | Layer | Choice | Why |
 |---|---|---|
-| Framework | Astro | Static-site friendly, Markdown content collections, TypeScript support |
+| Framework | Astro | Static-site friendly, content collections, TypeScript support |
 | Styling | Tailwind CSS | Utility-first, no runtime CSS |
-| Content | Markdown files in `site/src/content/` | Git-backed, CMS-editable, human-readable |
+| Content | Files in `site/src/content/` | Git-backed, CMS-editable, human-readable |
 | CMS | Pages CMS | Free, Git-backed, no database |
-| Hosting | GitHub Pages | Free for public repos, automatic via Actions |
-| Booking | Calendly embed | No backend required, public immediately |
+| Hosting (production) | GitHub Pages | Free for public repos, deploys from `main` |
+| Hosting (preview) | Vercel | Deploys from `dev`; shows drafts before they go live |
+| Booking | Calendly embed | Configured via `bookingUrl` in Site Settings; no backend required |
 
 ## Repository layout
 
 ```
 professional_site/
-  .pages.yml              ← Pages CMS configuration
+  .pages.yml                  ← Pages CMS configuration
+  .husky/pre-commit           ← Pre-commit hook (Prettier + ESLint on staged files)
   .github/
     workflows/
-      ci.yml              ← Build + deploy to GitHub Pages on push to main
+      ci.yml                  ← Lint, check, build, deploy (GitHub Pages on main)
+      update-pr-branches.yml  ← Auto-updates open PRs when dev advances
+      cms-notes-to-issues.yml ← Opens GitHub issues from notesToDevTeam CMS fields
   site/
-    astro.config.mjs      ← Sets site URL and /profesional_site base path
+    astro.config.mjs          ← Base path: /profesional_site (GH Pages) or / (Vercel)
     src/
-      pages/              ← Route files (.astro)
-      components/         ← Nav, Footer, etc.
-      layouts/            ← BaseLayout wrapping all pages
+      pages/                  ← Route files (.astro)
+      components/             ← Nav, Footer, etc.
+      layouts/                ← BaseLayout wrapping all pages
       content/
-        settings/         ← main.json (name, tagline, bio, email)
-        projects/         ← Work/portfolio items (.md)
+        settings/             ← main.json (name, tagline, bio, bookingUrl, etc.)
+        projects/             ← Portfolio items (.md)
+        writing/              ← Blog posts and essays (.md)
+        testimonials/         ← Colleague quotes (.json)
+      content.config.ts       ← Zod schemas for all four collections
       styles/
         global.css
     public/
-      media/              ← Uploaded images (managed by Pages CMS)
-  docs/                   ← Project documentation (this folder)
+      media/                  ← Uploaded images (managed by Pages CMS)
+  docs/                       ← Project documentation (this folder)
 ```
 
-## Deployment flow
+## Content model
+
+| Collection | Format | Fields |
+|---|---|---|
+| **settings** | JSON (single file) | name, tagline, bio, email, bookingUrl, photo, linkedin, instagram, notesToDevTeam |
+| **projects** | Markdown | title, description, image, tags, link, date, featured, notesToDevTeam |
+| **writing** | Markdown | title, description, date, tags, draft, notesToDevTeam |
+| **testimonials** | JSON | author, role, quote, featured, notesToDevTeam |
+
+`notesToDevTeam` is never rendered on the site. When non-empty and committed to `dev`, the `cms-notes-to-issues` workflow creates a GitHub issue automatically.
+
+## Git / deployment flow
+
+Two-branch model:
 
 ```
-Push to main
-  → GitHub Actions CI (ci.yml)
-    → npm install (regenerates lockfile for Linux)
-    → astro build
-    → upload artifact
-  → GitHub Pages deploy
+feat/* branch
+  → PR targeting dev
+  → CI (lint, astro-check, build)
+  → auto-merge into dev
+    → Vercel preview rebuilds (~1 min)
+    → preview at https://profesional-site.vercel.app
+
+dev → main (release PR)
+  → CI + deploy
+    → GitHub Pages rebuilds (~1 min)
     → live at https://rainonej.github.io/profesional_site/
 ```
 
-## Single editor path
+When Agreni edits via Pages CMS:
+- Pages CMS commits to `dev`
+- Vercel auto-deploys the preview
+- Developer opens a `dev → main` release PR when ready to go live
 
-**Use Pages CMS as the one place to edit content.**
+## Base path
 
-1. Go to [pagescms.org](https://pagescms.org), sign in with GitHub, and select this repo.
-2. Edit **Site Settings** (name, tagline, bio, email, photo, social links) or **Work / Projects** (portfolio items).
-3. Save → the CMS commits changes to the repo → GitHub Actions rebuilds → the site updates in about a minute.
+`astro.config.mjs` uses `process.env.GITHUB_ACTIONS === 'true'` to conditionally set the base:
+- GitHub Pages build: `base: '/profesional_site'`
+- Vercel / local: `base: '/'`
 
-Pages CMS is the only supported editor. The Decap CMS admin has been removed.
+All internal links use `import.meta.env.BASE_URL` as a prefix.
 
-## Image upload flow
+## Image upload
 
-- **Where images go:** All CMS-uploaded images are stored in `site/public/media/`. The site and both CMSes use this folder.
-- **In Pages CMS:** When you add or change an image on a field (e.g. Profile Photo, Cover Image), choose or upload a file; it is saved into the `media` library and written to `site/public/media/`. The path in content is relative to the site (e.g. `/media/filename.jpg`).
-- **In the repo:** `site/public/media/` is committed to Git. Keep image filenames simple (letters, numbers, hyphens) to avoid path issues.
-
-## Content editing flow
-
-```
-Agreni opens Pages CMS (pagescms.org)
-  → signs in with GitHub
-  → selects rainonej/profesional_site repo
-  → edits a post or page field
-  → saves → CMS commits Markdown to repo
-  → GitHub Actions rebuilds → site updates in ~1 min
-```
-
-## Base path note
-
-The site is hosted at `/profesional_site/` (GitHub Pages subdirectory), so `astro.config.mjs` sets:
-```js
-site: 'https://rainonej.github.io',
-base: '/profesional_site',
-```
-All internal links must use `import.meta.env.BASE_URL` as a prefix.
+All CMS-uploaded images go to `site/public/media/` and are committed to Git. Keep filenames simple (letters, numbers, hyphens) to avoid path issues.

--- a/docs/collaborator-walkthrough.md
+++ b/docs/collaborator-walkthrough.md
@@ -4,87 +4,141 @@ This guide is for Agreni. You do not need to touch code, the terminal, or GitHub
 
 ---
 
+## Your two site URLs
+
+| URL | What it is |
+|-----|-----------|
+| **https://rainonej.github.io/profesional_site/** | Live site — what the world sees |
+| **https://profesional-site.vercel.app** | Preview site — reflects the latest saved drafts; not indexed by Google |
+
+When you save something in Pages CMS it goes to the preview site first (~1 minute). The live site is updated manually by the developer when you're ready to publish.
+
+---
+
 ## Getting into Pages CMS
 
 1. Go to **https://app.pagescms.org**
 2. Click **Sign in with GitHub** and authorize it
 3. You'll land on a project list — click **profesional_site**
-4. You're in. The left sidebar has:
-   - **Site Settings** — edit your name, tagline, bio, email, and social links
-   - **Work / Projects** — add or edit portfolio/work entries
-   - **Media** — upload images
-   - **Settings** — this is the raw CMS config file, ignore it
+4. You're in. The left sidebar shows:
+   - **Site Settings** — your name, bio, email, social links, Calendly URL
+   - **Work / Projects** — portfolio entries
+   - **Writing** — blog posts and essays
+   - **Testimonials** — quotes from colleagues
+   - **Media** — image uploads
 
-> **Important:** "Settings" (gear icon) in the sidebar is NOT where you edit your content. That's the technical config file. Your content lives under "Site Settings" and "Work / Projects."
-
----
-
-## Edit your bio and tagline
-
-1. Click **Site Settings** in the sidebar
-2. You'll see fields for Name, Tagline, Bio, Email, Photo, LinkedIn, Instagram
-3. Edit any field
-4. Click **Save** (top right)
-5. The site rebuilds automatically — live in ~1 minute at https://rainonej.github.io/profesional_site/
+> **Ignore the gear icon ("Settings").** That is a raw config file — not your content. Your content is in the four sections above.
 
 ---
 
-## Add a new work entry / project
+## Edit your bio, tagline, and contact info
 
-1. Click **Work / Projects** in the sidebar
-2. Click **Add an entry** (top right)
+1. Click **Site Settings**
+2. Edit any field:
+   - **Name** — shown in the nav and hero
+   - **Tagline** — short line under your name on the homepage
+   - **Bio** — your about-page text; line breaks are preserved
+   - **Email** — shown on the About and Contact pages
+   - **Booking URL** — your Calendly link (e.g. `https://calendly.com/yourname/30min`); leave empty to hide the booking widget
+   - **Photo** — upload your headshot
+   - **LinkedIn / Instagram** — full URLs, shown as icon links
+3. Click **Save** (top right)
+
+---
+
+## Add or edit a work entry / project
+
+1. Click **Work / Projects**
+2. Click **Add an entry** (top right) — or click an existing entry to edit it
 3. Fill in:
    - **Title** — required
-   - **Description** — one or two sentences shown on the homepage card
-   - **Image** — upload via the Media button (optional)
-   - **Tags** — e.g. `Research`, `Curriculum`, `STEM`
-   - **External link** — link to a paper, report, or project page (optional)
-   - **Date** — used for sorting
-   - **Show on homepage** — check this to feature it on the home page (max 3 shown)
-   - **Details** — longer description, shown if you click into the entry (optional)
+   - **Description** — one or two sentences shown in the work grid
+   - **Image** — optional cover image (upload via the Media button)
+   - **Tags** — e.g. `Research`, `Curriculum`, `STEM`; press Enter after each
+   - **External link** — link to a paper, report, or published project (optional)
+   - **Date** — used for sorting (newest first)
+   - **Show on homepage** — turn on to feature this entry on the homepage (max 3 shown)
+   - **Details** — longer text shown when someone clicks into the entry
 4. Click **Save**
 
 ---
 
-## Upload an image / headshot
+## Write a blog post or essay
 
-**Option A — from Pages CMS:**
+1. Click **Writing**
+2. Click **Add an entry** to start a new post, or click an existing one to edit
+3. Fill in:
+   - **Title** — required
+   - **Description** — one sentence shown in the writing list and on the homepage strip
+   - **Date** — publish date (used for ordering)
+   - **Tags** — e.g. `Curriculum`, `Equity`, `Teaching`; press Enter after each
+   - **Draft** — turn on to hide the post from the site while you're working on it; turn off when ready to publish
+   - **Post** — the full text; supports headings, bold/italic, lists, and links
+4. Click **Save**
+
+Posts marked as **Draft** will appear in the preview site but not on the live site, so you can review them before publishing.
+
+---
+
+## Add or edit a testimonial
+
+1. Click **Testimonials**
+2. Click **Add an entry** — or click an existing one
+3. Fill in:
+   - **Name** — the person's full name
+   - **Role / Affiliation** — e.g. `Program Director, Girls Inc. NYC` (optional)
+   - **Quote** — the testimonial text (no quotation marks — they are added automatically)
+   - **Show on homepage** — turn on to feature this quote in the homepage section
+4. Click **Save**
+
+---
+
+## Upload an image or headshot
+
+**Option A — from the Media section:**
 1. Click **Media** in the sidebar
-2. If you see "Media folder missing," click **Create folder** — this sets up the folder on GitHub
-3. Click **Upload** and pick a file from your computer
-4. The image is now available to use in any entry's Image field
+2. If you see "Media folder missing," click **Create folder**
+3. Click **Upload** and choose a file from your computer
 
-**Option B — from an entry:**
+**Option B — from inside an entry:**
 1. Open any entry in Work / Projects or Site Settings
 2. Click the Image field
 3. A media picker opens — you can upload directly from there
 
 ---
 
-## Edit an existing work entry
+## Leave a note for the developer
 
-1. Click **Work / Projects**
-2. Click **Edit** next to the entry you want to change
-3. Make your edits
-4. Click **Save**
+Every content type has a **"Notes to dev team"** field at the bottom. Use it to describe a change you need, something that looks wrong, or a question. You do not need to email or message separately.
+
+**How it works:**
+1. Type your note in the "Notes to dev team" field of any entry (or in Site Settings)
+2. Click **Save**
+3. A GitHub issue is created automatically — the developer will see it in their task list
+4. Once the developer resolves it, they'll ask you to clear the field and close the issue
+
+Your note is **never shown on the live site.**
 
 ---
 
 ## After saving — how long until the site updates?
 
-About 1 minute. GitHub Actions sees the new commit from Pages CMS and rebuilds the site automatically. Refresh https://rainonej.github.io/profesional_site/ after a minute to see the change.
+About 1 minute. The preview site (Vercel) updates first. The live site (GitHub Pages) is updated when the developer merges changes to the main branch — usually at the end of a development session.
 
 ---
 
 ## What you can edit without a developer
 
-- Name, tagline, bio, email, social links (Site Settings)
-- Work/project entries — add, edit, delete, reorder
+- Name, tagline, bio, email, social links, Calendly booking URL
+- Work/project entries — add, edit, delete, reorder by date
+- Writing posts — draft, publish, edit
+- Testimonials — add, edit, feature on homepage
 - Images via Media manager
+- Leave notes for the developer via the "Notes to dev team" field
 
 ## What requires a developer
 
-- Adding new types of pages (Research, Teaching, Blog — coming later)
+- Adding new page types or sections
 - Changing layout, fonts, or colors
-- Replacing the Calendly booking link (search the codebase for `PLACEHOLDER`)
 - Custom domain setup
+- Publishing a batch of changes from the preview site to the live site (this is intentional — you can draft freely without it going live)


### PR DESCRIPTION
## Summary
- **New `docs/README.md`** — index table listing all docs with audience (Agreni vs dev) and brief description of each
- **Rewrote `collaborator-walkthrough.md`** — now covers all four content types (Settings, Projects, Writing, Testimonials), the Notes to dev team field, both preview/live URLs, and an updated "what requires a developer" list
- **Updated `architecture.md`** — reflects current state: two-branch model, Vercel preview, all four Zod-typed collections, three new GitHub Actions workflows, conditional base path

## Test plan
- [ ] Read collaborator-walkthrough.md as if you were Agreni — does it cover everything needed to edit the site independently?
- [ ] Verify docs/README.md links resolve correctly
- [ ] No code changes — CI lint/build should pass trivially

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)