### PR TITLE
docs: split README into public overview + CONTRIBUTING for developers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+## Prerequisites
+
+- Node 20+
+- npm
+
+## Setup
+
+```bash
+cd site
+npm install
+```
+
+This also activates the pre-commit hook (husky + lint-staged), which runs Prettier and ESLint on staged files before every commit. If hooks stop firing, re-run `npm install` to restore them.
+
+## Development
+
+```bash
+cd site
+npm run dev       # local dev server at http://localhost:4321
+npm run build     # production build to site/dist/
+```
+
+## Linting
+
+CI runs ESLint (Astro/JS/TS), stylelint (CSS), Prettier (formatting), and yamllint (`.pages.yml`, workflow files). Locally:
+
+```bash
+cd site
+npm run lint      # check only
+npm run lint:fix  # fix and format in-place
+```
+
+## Branch model
+
+- **Feature/fix branches** are created from `dev` and named `feat/<description>` or `fix/<description>`.
+- **PRs target `dev`** (not `main`).
+- **Release PRs** go from `dev` → `main` when ready to deploy to GitHub Pages.
+- Never force-push `dev` or `main`.
+
+## Commit format
+
+[Conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:`, `docs:`, etc.
+
+## Merging
+
+Always merge with auto-merge so the PR lands after CI passes:
+
+```bash
+gh pr merge <number> --auto --merge
+```
+
+## Reference
+
+- CI pipeline details: [docs/ci.md](docs/ci.md)
+- Label taxonomy and issue workflow: [docs/issue-labels.md](docs/issue-labels.md)
+- Project management conventions: [docs/project-management.md](docs/project-management.md)

--- a/README.md
+++ b/README.md
@@ -1,62 +1,33 @@
 # professional_site
 
-**Live site: https://rainonej.github.io/profesional_site/**
+A personal / professional website for Agreni, built with Astro + Tailwind CSS.
 
-Base path in `site/astro.config.mjs` matches the GitHub repo name (`profesional_site`); no change needed.
+**Live site:** https://rainonej.github.io/profesional_site/
 
-A personal / professional demo website built with Astro + Tailwind CSS.
+**Preview site (Vercel):** https://profesional-site.vercel.app
 
-## Structure
+---
+
+## Repository structure
 
 ```
 professional_site/
 ├── CLAUDE.md           — Claude Code autonomy configuration
+├── CONTRIBUTING.md     — Developer setup and workflow
 ├── README.md           — this file
-├── .gitignore
+├── .pages.yml          — Pages CMS configuration
 ├── .github/
-│   └── workflows/      — CI/CD (lint, build, deploy)
-└── site/               — website source
+│   └── workflows/      — CI/CD (lint, build, deploy, Claude agent)
+└── site/               — website source (Astro)
 ```
 
-## Development
+## For site editors
 
-```bash
-cd site
-npm install
-npm run dev
-```
+See [docs/collaborator-walkthrough.md](docs/collaborator-walkthrough.md) for instructions on editing content, uploading media, and leaving feedback via the preview site.
 
-## Lint
+## For developers
 
-CI runs ESLint (Astro/JS/TS), stylelint (CSS), Prettier (format), and yamllint (`.pages.yml`, workflows, CMS config). Locally:
-
-```bash
-cd site
-npm ci
-npm run lint        # check only
-npm run lint:fix    # fix and format
-```
-
-## Pre-commit hook
-
-`npm install` activates a pre-commit hook (husky + lint-staged) that automatically runs Prettier and ESLint on staged files before every commit. It fixes what it can in-place and blocks the commit on unfixable errors — so CI formatting failures can't slip through locally.
-
-This is set up automatically on `npm install`. If hooks aren't firing, run:
-
-```bash
-cd site && npm install   # re-runs the prepare script which sets core.hooksPath
-```
-
-## Build
-
-```bash
-cd site
-npm run build
-```
-
-## Deployment
-
-Static output is generated to `site/dist/`. Deployed to GitHub Pages.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, branch model, linting, CI, and PR workflow.
 
 ---
 


### PR DESCRIPTION
## Summary

- `README.md` rewritten as a public-facing project overview with live site link, Vercel preview link, repo structure, and pointers for editors and developers
- `CONTRIBUTING.md` created with full developer reference: setup, dev server, lint, pre-commit hook, build, branch model, commit format, merge workflow, and doc pointers

## Why

The old README was entirely dev-setup commands with no project context for visitors or Agreni. Splitting by audience makes both files cleaner and easier to maintain.

## Test plan

- [ ] README renders correctly on GitHub (check formatting and links)
- [ ] CONTRIBUTING.md renders correctly on GitHub
- [ ] CI passes (no code changes, lint is unaffected)