### PR TITLE
feat: add markdownlint, .editorconfig, and full VS Code toolchain integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Preserve trailing spaces (two spaces = intentional line break in Markdown)
+trim_trailing_whitespace = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         working-directory: site
         run: npm run lint
 
+      - name: Lint Markdown
+        run: ./site/node_modules/.bin/markdownlint-cli2
+
   astro-check:
     runs-on: ubuntu-latest
     needs: lint

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,3 @@
+{
+  "globs": ["**/*.md", "!**/node_modules/**", "!site/dist/**", "!.gh-ci-issues/**"]
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,10 @@
 {
-  "recommendations": ["bradlc.vscode-tailwindcss"]
+  "recommendations": [
+    "astro-build.astro-vscode",
+    "bradlc.vscode-tailwindcss",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "stylelint.vscode-stylelint",
+    "DavidAnson.vscode-markdownlint"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-  "css.lint.unknownAtRules": "ignore"
+  "css.lint.unknownAtRules": "ignore",
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "eslint.validate": ["javascript", "typescript", "astro"],
+  "stylelint.validate": ["css"],
+  "prettier.requireConfig": true
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ All autonomous actions are sandboxed to this repository:
 
 The demo website lives in the `/site` subdirectory.
 
-```
+```text
 professional_site/
 ├── CLAUDE.md           ← this file
 ├── README.md
@@ -74,7 +74,7 @@ Two-branch model: `dev` is the integration branch; `main` is production (GitHub 
 - **Styling**: Tailwind CSS
 - **CMS**: Pages CMS (git-backed, configured in `.pages.yml`)
 - **Hosting (production)**: GitHub Pages (deploys from `main`)
-- **Hosting (preview)**: Vercel (deploys from `dev`; preview at https://profesional-site.vercel.app)
+- **Hosting (preview)**: Vercel (deploys from `dev`; preview at <https://profesional-site.vercel.app>)
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,10 @@
 
 | | URL | Notes |
 |---|---|---|
-| **Live site** | https://rainonej.github.io/profesional_site/ | Public — what the world sees |
-| **Pages CMS** | https://app.pagescms.org | Edit content here — requires GitHub login |
-| **Public preview** | https://profesional-site.vercel.app | Latest `dev` build — public, no login, **no comment toolbar** |
-| **Review preview** | https://profesional-site-git-dev-rainonejs-projects.vercel.app | Same content — requires GitHub login, **has comment toolbar** |
+| **Live site** | <https://rainonej.github.io/profesional_site/> | Public — what the world sees |
+| **Pages CMS** | <https://app.pagescms.org> | Edit content here — requires GitHub login |
+| **Public preview** | <https://profesional-site.vercel.app> | Latest `dev` build — public, no login, **no comment toolbar** |
+| **Review preview** | <https://profesional-site-git-dev-rainonejs-projects.vercel.app> | Same content — requires GitHub login, **has comment toolbar** |
 
 > **Why two preview links?** Vercel's comment toolbar only works on "Preview" deployments, not on the public "Production" alias. Use the review preview link any time you want to leave feedback.
 
@@ -23,7 +23,7 @@ When you save something in Pages CMS it appears on the public preview within abo
 
 #### Step 1 — Sign in
 
-1. Go to **https://app.pagescms.org**
+1. Go to **<https://app.pagescms.org>**
 2. Click **Sign in with GitHub** and authorize the app
 
    ![Screenshot: Pages CMS sign-in page with "Sign in with GitHub" button](docs/screenshots/pages-cms-signin.png)
@@ -121,6 +121,7 @@ When you save something in Pages CMS it appears on the public preview within abo
 #### Uploading images
 
 **Option A — from the Media section:**
+
 1. Click **Media** in the sidebar
 2. If you see "Media folder missing," click **Create folder**
 3. Click **Upload** and choose a file from your computer
@@ -128,6 +129,7 @@ When you save something in Pages CMS it appears on the public preview within abo
    ![Screenshot: Media section with Upload button](docs/screenshots/pages-cms-media.png)
 
 **Option B — directly inside an entry:**
+
 1. Open any entry in Work / Projects or Site Settings
 2. Click the **Image** field
 3. A media picker opens — click **Upload** to add a file directly from there
@@ -163,6 +165,7 @@ When you want to request a design change, flag a bug, or ask for anything to be 
 The "Convert to Issue" button only appears after the Vercel GitHub Issues integration is installed and scoped to this project. **This is a one-time setup done by the developer** — if the GitHub icon is missing from comment threads, the integration is not yet installed.
 
 **Developer: install it here:**
+
 1. Go to [vercel.com/marketplace/gh-issues](https://vercel.com/marketplace/gh-issues)
 2. Click **Add Integration**
 3. Scope it to the **rainonej's projects** team and the **profesional-site** project
@@ -176,7 +179,7 @@ Once installed, any team member (not just the developer) can convert comments to
 #### Step 1 — Sign in and open the review preview
 
 1. Sign in to your GitHub account in the browser you'll use
-2. Go to **https://profesional-site-git-dev-rainonejs-projects.vercel.app**
+2. Go to **<https://profesional-site-git-dev-rainonejs-projects.vercel.app>**
 3. The Vercel toolbar appears at the **bottom of the page**
 
 > If you don't see the toolbar, visit [vercel.com](https://vercel.com) first and sign in with GitHub, then return to the preview link.
@@ -286,6 +289,7 @@ Vercel has three environment tiers that behave differently:
 | **Development** | localhost | N/A | N/A |
 
 **How the Vercel feedback workflow works:**
+
 - The Production alias (`profesional-site.vercel.app`) reflects the latest `dev` push and is public, but has no comment toolbar.
 - The branch Preview URL for `dev` is stable: `profesional-site-git-dev-rainonejs-projects.vercel.app` — this is what Agreni uses for reviewing and leaving comments.
 - Vercel also creates a per-PR Preview deployment for every open PR (shown as a bot comment on the PR itself).
@@ -303,6 +307,7 @@ The GitHub icon in comment threads only appears after installing the Vercel GitH
 Only team members (Vercel accounts with access to the project) can convert comments to issues — this is not available to anonymous viewers.
 
 **Vercel settings:**
+
 - [Project environments](https://vercel.com/rainonejs-projects/profesional-site/settings/environments/preview) — configure Preview environment variables, protection, and branch targeting
 - [Vercel environments docs](https://vercel.com/docs/deployments/environments#custom-environments) — official reference
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A personal / professional website for Agreni, built with Astro + Tailwind CSS.
 
 | | URL | Access |
 |---|---|---|
-| **Live site** | https://rainonej.github.io/profesional_site/ | Public |
-| **Pages CMS** | https://app.pagescms.org | Requires GitHub login |
-| **Public preview (Vercel)** | https://profesional-site.vercel.app | Public — reflects latest `dev`, no comment toolbar |
-| **Review preview (Vercel)** | https://profesional-site-git-dev-rainonejs-projects.vercel.app | Requires GitHub login — has comment toolbar for feedback |
+| **Live site** | <https://rainonej.github.io/profesional_site/> | Public |
+| **Pages CMS** | <https://app.pagescms.org> | Requires GitHub login |
+| **Public preview (Vercel)** | <https://profesional-site.vercel.app> | Public — reflects latest `dev`, no comment toolbar |
+| **Review preview (Vercel)** | <https://profesional-site-git-dev-rainonejs-projects.vercel.app> | Requires GitHub login — has comment toolbar for feedback |
 
 The live site reflects `main`. The public preview reflects `dev` and updates within ~1 minute of any CMS save or code push. The review preview URL is generated per deployment — see [CONTRIBUTING.md — Vercel environments](CONTRIBUTING.md#vercel-environments) for details.
 
@@ -19,7 +19,7 @@ The live site reflects `main`. The public preview reflects `dev` and updates wit
 
 ## Repository structure
 
-```
+```text
 professional_site/
 ├── CLAUDE.md           — Claude Code autonomy configuration
 ├── CONTRIBUTING.md     — Instructions for site owner, developers, and AI agents

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@
 
 ## Repository layout
 
-```
+```text
 professional_site/
   .pages.yml                  ← Pages CMS configuration
   .husky/pre-commit           ← Pre-commit hook (Prettier + ESLint on staged files)
@@ -57,7 +57,7 @@ To leave feedback or request changes, use Vercel comments on the preview site �
 
 Two-branch model:
 
-```
+```text
 feat/* branch
   → PR targeting dev
   → CI (lint, astro-check, build)
@@ -72,6 +72,7 @@ dev → main (release PR)
 ```
 
 When Agreni edits via Pages CMS:
+
 - Pages CMS commits to `dev`
 - Vercel auto-deploys the preview
 - Developer opens a `dev → main` release PR when ready to go live
@@ -79,6 +80,7 @@ When Agreni edits via Pages CMS:
 ## Base path
 
 `astro.config.mjs` uses `process.env.GITHUB_ACTIONS === 'true'` to conditionally set the base:
+
 - GitHub Pages build: `base: '/profesional_site'`
 - Vercel / local: `base: '/'`
 

--- a/docs/collaborator-walkthrough.md
+++ b/docs/collaborator-walkthrough.md
@@ -8,9 +8,9 @@ This guide is for Agreni. You do not need to touch code, the terminal, or GitHub
 
 | URL | What it is |
 |-----|-----------|
-| **https://rainonej.github.io/profesional_site/** | Live site — what the world sees |
-| **https://profesional-site.vercel.app** | Public preview — reflects the latest `dev` changes; not indexed by Google; no comment toolbar |
-| **https://profesional-site-git-dev-rainonejs-projects.vercel.app** | Review preview — same content, requires GitHub login, has the Vercel comment toolbar |
+| **<https://rainonej.github.io/profesional_site/>** | Live site — what the world sees |
+| **<https://profesional-site.vercel.app>** | Public preview — reflects the latest `dev` changes; not indexed by Google; no comment toolbar |
+| **<https://profesional-site-git-dev-rainonejs-projects.vercel.app>** | Review preview — same content, requires GitHub login, has the Vercel comment toolbar |
 
 When you save something in Pages CMS it goes to the previews first (~1 minute). The live site is updated manually by the developer when you're ready to publish.
 
@@ -20,7 +20,7 @@ When you save something in Pages CMS it goes to the previews first (~1 minute). 
 
 ## Getting into Pages CMS
 
-1. Go to **https://app.pagescms.org**
+1. Go to **<https://app.pagescms.org>**
 2. Click **Sign in with GitHub** and authorize it
 3. You'll land on a project list — click **profesional_site**
 4. You're in. The left sidebar shows:
@@ -99,11 +99,13 @@ Posts marked as **Draft** will appear in the preview site but not on the live si
 ## Upload an image or headshot
 
 **Option A — from the Media section:**
+
 1. Click **Media** in the sidebar
 2. If you see "Media folder missing," click **Create folder**
 3. Click **Upload** and choose a file from your computer
 
 **Option B — from inside an entry:**
+
 1. Open any entry in Work / Projects or Site Settings
 2. Click the Image field
 3. A media picker opens — you can upload directly from there
@@ -114,7 +116,7 @@ Posts marked as **Draft** will appear in the preview site but not on the live si
 
 When you're reviewing the preview site and want to request a change or flag something:
 
-1. Open the review preview: **https://profesional-site-git-dev-rainonejs-projects.vercel.app**
+1. Open the review preview: **<https://profesional-site-git-dev-rainonejs-projects.vercel.app>**
 2. Click the **Comment** button (appears in the Vercel toolbar at the bottom of the page)
 3. Click anywhere on the page to pin a comment — describe what you'd like changed
 4. In the comment thread, click **Create GitHub Issue** to send it directly to the developer's task list

--- a/docs/costs.md
+++ b/docs/costs.md
@@ -17,9 +17,11 @@
 ## Scenarios
 
 ### Demo-only (current state)
+
 Near-zero cost. Everything runs on free tiers. No custom domain, no professional email.
 
 ### Production — minimal
+
 Add a domain (~$12–15/yr via Namecheap) and professional email.
 
 | Addition | Option A | Option B |
@@ -33,7 +35,8 @@ Add a domain (~$12–15/yr via Namecheap) and professional email.
 **Estimated total: ~$36–50/yr** (domain + basic email)
 
 ### Production — premium visual editing
-Replace Pages CMS / Decap with CloudCannon for a Squarespace-grade visual editor. CloudCannon pricing is materially higher — check https://cloudcannon.com/pricing/ for current rates.
+
+Replace Pages CMS / Decap with CloudCannon for a Squarespace-grade visual editor. CloudCannon pricing is materially higher — check <https://cloudcannon.com/pricing/> for current rates.
 
 ---
 

--- a/docs/demo-plan.md
+++ b/docs/demo-plan.md
@@ -7,23 +7,27 @@ Show Agreni a credible, live academic website that she can edit herself — with
 ## Phases
 
 ### Phase 1 — Scaffold (done)
+
 - Astro project in `site/` with Tailwind CSS
 - Pages: Home, About, Work, Contact
 - Placeholder content (name, tagline, bio)
 - Local build passing
 
 ### Phase 2 — Booking (done)
+
 - Calendly popup button on Home hero ("Book a conversation")
 - Calendly inline embed on Contact page
 - Both use `PLACEHOLDER` username — swap when Agreni has a Calendly account
 
 ### Phase 3 — CMS configuration (done)
+
 - `.pages.yml` at repo root → Pages CMS can edit pages and blog posts
 - `site/public/admin/` → Decap CMS as an alternative
 
 ### Phase 4 — Deployment (done)
+
 - GitHub Pages via Actions (`ci.yml`)
-- Live at: https://rainonej.github.io/profesional_site/
+- Live at: <https://rainonej.github.io/profesional_site/>
 - Default branch set to `main`
 - Deploy environment protection configured for `main`
 

--- a/docs/epic-briefs.md
+++ b/docs/epic-briefs.md
@@ -11,6 +11,7 @@ Epics are parent issues with title **Epic: &lt;name&gt;** and label **epic**. Ea
 **Context:** The repo currently supports both Pages CMS (`.pages.yml`) and Decap CMS (`site/public/admin/`). CI and README assume GitHub Pages; Decap is set up for Netlify. This confuses contributors and makes docs and automation harder.
 
 **Success criteria:**
+
 - A single editor path is documented (e.g. "Use Pages CMS at app.pagescms.org").
 - Config and UI for the rejected path are removed or clearly deprecated (with a short note where to look if someone needs them).
 
@@ -29,6 +30,7 @@ Epics are parent issues with title **Epic: &lt;name&gt;** and label **epic**. Ea
 **Context:** Target audiences are PhD committees, education community, and consulting clients. Current copy and IA don't reflect that.
 
 **Success criteria:**
+
 - Homepage, about, and nav speak to those audiences.
 - Messaging aligns with `docs/project-brief.md` (tone, content pillars).
 
@@ -47,6 +49,7 @@ Epics are parent issues with title **Epic: &lt;name&gt;** and label **epic**. Ea
 **Context:** Project brief calls for public scholarship and evidence; currently there is no blog or testimonials. Settings are in `main.json` with limited fields.
 
 **Success criteria:**
+
 - Blog/writing collection and at least one page; CMS can create/edit posts.
 - Testimonials collection and a place they appear (e.g. homepage or about).
 - Richer settings if needed for other epics (e.g. booking URL).
@@ -66,6 +69,7 @@ Epics are parent issues with title **Epic: &lt;name&gt;** and label **epic**. Ea
 **Context:** Settings are loaded via raw JSON import; some content still has placeholder text and PLACEHOLDER Calendly URL.
 
 **Success criteria:**
+
 - Schemas (e.g. content collections or validated settings) where we want type safety.
 - Placeholder copy and booking URL replaced by real values or by editable settings.
 
@@ -84,6 +88,7 @@ Epics are parent issues with title **Epic: &lt;name&gt;** and label **epic**. Ea
 **Context:** Pages CMS (or chosen CMS) fields may have no hints; contributors may not know which tool to use.
 
 **Success criteria:**
+
 - Major editable fields have help/hint text where useful.
 - `docs/architecture.md` (or collaborator doc) states the single editor path.
 
@@ -102,6 +107,7 @@ Epics are parent issues with title **Epic: &lt;name&gt;** and label **epic**. Ea
 **Context:** Content types may have a "notes to dev" field; we want automation or a clear process to turn those into issues.
 
 **Success criteria:**
+
 - A defined path from CMS note to issue (or equivalent).
 - If it requires tokens/secrets, that setup is documented and done by a human.
 
@@ -120,6 +126,7 @@ Epics are parent issues with title **Epic: &lt;name&gt;** and label **epic**. Ea
 **Context:** CI already runs lint and build; no astro check yet. No preview deploys.
 
 **Success criteria:**
+
 - `astro check` (or equivalent) in CI.
 - Preview deploys for PRs (or doc for how to do it).
 - Branch protection/required checks documented or configured.
@@ -139,6 +146,7 @@ Epics are parent issues with title **Epic: &lt;name&gt;** and label **epic**. Ea
 **Context:** Calendly URL is still PLACEHOLDER; booking may be hardcoded. We want it configurable and working.
 
 **Success criteria:**
+
 - Booking link works in production.
 - Booking URL comes from settings (or a single config) so the site owner can change it without code.
 
@@ -157,6 +165,7 @@ Epics are parent issues with title **Epic: &lt;name&gt;** and label **epic**. Ea
 **Context:** Nav is currently Home / About / Work / Contact. Writing and "who I work with" may need to be first-class.
 
 **Success criteria:**
+
 - Nav and layout support a writing-first and collaboration-friendly UX (e.g. Writing/Research and Collaboration visible).
 - Aligns with project brief without requiring new content types in this epic.
 
@@ -175,6 +184,7 @@ Epics are parent issues with title **Epic: &lt;name&gt;** and label **epic**. Ea
 **Context:** We have some docs (collaborator walkthrough, lint, costs, architecture). We need a coherent pack and real content for launch.
 
 **Success criteria:**
+
 - Docs: for-agreni, content-model, deployment, README aligned.
 - Launch content: site owner has provided or scheduled content for key pages and any new collections.
 

--- a/docs/issue-labels.md
+++ b/docs/issue-labels.md
@@ -45,7 +45,7 @@ So the useful distinction is how we **design** each label set:
 | **human-dev** | `#F9D0C4` (peach) or `#FBCA04` (yellow) | Needs human developer: judgment, security, infra, or complex debugging. | Preview deploy setup, auth/credentials, performance investigation, architectural decisions. |
 | **needs-site-owner** | `#C5DEF5` (light blue) or `#D93F0B` (red) | Needs the site/product owner: content, copy, positioning, or product/priority decisions. | Replace placeholder copy, choose booking URL, approve IA, provide testimonials or blog content. |
 
-**Rules of thumb**
+### Rules of thumb
 
 - **simple-ai**: “A clear PR description could be written and a capable AI could implement it without opening 10 files.”
 - **agentic-ai**: “Requires reading the codebase, docs, and maybe the audit; might touch many files or have ambiguous steps.”

--- a/docs/project-brief.md
+++ b/docs/project-brief.md
@@ -7,12 +7,15 @@ A demo personal academic website for **Agreni Batra**, built to evaluate whether
 ## Three target audiences
 
 ### 1. PhD admissions committees
+
 The site needs to communicate a clear research trajectory and intellectual identity: a concise "who I am" statement, stated research interests, and evidence of reflective engagement with education systems and pedagogy. Content should read as academic rather than promotional.
 
 ### 2. Education / curriculum / teaching community
+
 The site functions as public scholarship: short essays, practice-to-research reflections, and project writeups that translate classroom and curriculum work into ideas others can reuse. A blog format that posts reflective, research-connected writing reinforces professional credibility without feeling like marketing copy.
 
 ### 3. Consulting clients
+
 Contact and booking must be frictionless. An obvious "Book a conversation" CTA goes directly to Calendly scheduling. A professional email link is the fallback. Visitors should be able to book time without leaving the site.
 
 ## Content pillars (placeholders — Agreni confirms/adjusts)
@@ -38,12 +41,14 @@ A neutral "hybrid" voice supports all three audiences from the same content arch
 ## Decisions Agreni needs to make
 
 ### For the demo
+
 - [ ] Preferred tone baseline: academic-first / public scholar / hybrid
 - [ ] Booking surface: inline Calendly embed vs pop-up link
 - [ ] Editor preference: Pages CMS (GitHub login) vs Decap CMS (can use Netlify Identity)
 - [ ] What to publish now vs leave as placeholder
 
 ### For production launch
+
 - [ ] Custom domain name
 - [ ] Professional email: Google Workspace vs Namecheap Private Email vs forwarding
 - [ ] Whether to use Decap's editorial workflow (PR-based drafts/approvals)
@@ -52,7 +57,8 @@ A neutral "hybrid" voice supports all three audiences from the same content arch
 ## Reference sites
 
 Academic personal sites worth studying:
-- https://www.laurafparks.com/
-- https://jasonanderson.blog/
-- https://shaohengko.github.io/
-- https://hugoblox.com/templates/academic-cv/
+
+- <https://www.laurafparks.com/>
+- <https://jasonanderson.blog/>
+- <https://shaohengko.github.io/>
+- <https://hugoblox.com/templates/academic-cv/>

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -4,7 +4,6 @@ This folder holds screenshots referenced in [CONTRIBUTING.md](../../CONTRIBUTING
 
 ## Files needed
 
-
 | Filename                         | What to capture                                                                                               |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `pages-cms-signin.png`           | Pages CMS homepage at [https://app.pagescms.org](https://app.pagescms.org) — the "Sign in with GitHub" button |
@@ -22,11 +21,9 @@ This folder holds screenshots referenced in [CONTRIBUTING.md](../../CONTRIBUTING
 | `vercel-comment-text.png`        | Vercel comment box with example feedback text typed in                                                        |
 | `vercel-create-issue.png`        | Vercel comment thread showing the "Create GitHub Issue" button                                                |
 
-
 ## How to add screenshots
 
 1. Take a screenshot of each item above
 2. Crop to the relevant area (no need to capture the full browser chrome)
 3. Save as PNG at the filename listed
 4. Commit and push — the images will appear inline in CONTRIBUTING.md
-

--- a/site/.markdownlint.json
+++ b/site/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-plugin-astro": "^1.2.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
+        "markdownlint-cli2": "^0.22.0",
         "prettier": "^3.3.3",
         "prettier-plugin-astro": "^0.14.0",
         "prettier-plugin-tailwindcss": "^0.6.8",
@@ -1067,6 +1068,18 @@
       "version": "10.0.2",
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "license": "MIT",
@@ -1126,6 +1139,12 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "dev": true
     },
     "node_modules/@types/mdast": {
@@ -2063,6 +2082,16 @@
     "node_modules/character-entities-legacy": {
       "version": "3.0.0",
       "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3666,6 +3695,30 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "license": "MIT",
@@ -3692,6 +3745,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-docker": {
@@ -3738,6 +3801,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "license": "MIT",
@@ -3769,6 +3842,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -3890,6 +3975,40 @@
       "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
       "dev": true
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.44",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.44.tgz",
+      "integrity": "sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3945,6 +4064,15 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/lint-staged": {
       "version": "16.4.0",
@@ -4169,12 +4297,165 @@
         "source-map-js": "^1.2.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "dev": true,
+      "dependencies": {
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.0.tgz",
+      "integrity": "sha512-mOC9BY/XGtdX3M9n3AgERd79F0+S7w18yBBTNIQ453sI87etZfp1z4eajqSMV70CYjbxKe5ktKvT2HCpvcWx9w==",
+      "dev": true,
+      "dependencies": {
+        "globby": "16.1.1",
+        "js-yaml": "4.1.1",
+        "jsonc-parser": "3.3.1",
+        "jsonpointer": "5.0.1",
+        "markdown-it": "14.1.1",
+        "markdownlint": "0.40.0",
+        "markdownlint-cli2-formatter-default": "0.0.6",
+        "micromatch": "4.0.8",
+        "smol-toml": "1.6.0"
+      },
+      "bin": {
+        "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2-formatter-default": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz",
+      "integrity": "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      },
+      "peerDependencies": {
+        "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/globby": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
+      "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true
+    },
+    "node_modules/markdownlint-cli2/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint/node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -4392,6 +4673,12 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true
     },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -4474,6 +4761,25 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "dev": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -4573,6 +4879,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -5191,6 +5516,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5648,6 +5998,15 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -6224,6 +6583,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map-js": {
@@ -6936,6 +7307,24 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unified": {

--- a/site/package.json
+++ b/site/package.json
@@ -7,8 +7,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "lint": "eslint . && stylelint \"src/**/*.css\" && prettier --check .",
-    "lint:fix": "eslint . --fix && stylelint \"src/**/*.css\" --fix && prettier --write .",
+    "lint": "eslint . && stylelint \"src/**/*.css\" && prettier --check . && markdownlint-cli2 \"src/**/*.md\" \"#node_modules\"",
+    "lint:fix": "eslint . --fix && stylelint \"src/**/*.css\" --fix && prettier --write . && markdownlint-cli2 --fix \"src/**/*.md\" \"#node_modules\"",
     "format": "prettier --write .",
     "prepare": "cd .. && git config core.hooksPath .husky || true"
   },
@@ -21,7 +21,11 @@
       "stylelint --fix",
       "prettier --write"
     ],
-    "*.{json,md,yml,yaml}": [
+    "*.md": [
+      "markdownlint-cli2 --fix",
+      "prettier --write"
+    ],
+    "*.{json,yml,yaml}": [
       "prettier --write"
     ]
   },
@@ -37,6 +41,7 @@
     "eslint-plugin-astro": "^1.2.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
+    "markdownlint-cli2": "^0.22.0",
     "prettier": "^3.3.3",
     "prettier-plugin-astro": "^0.14.0",
     "prettier-plugin-tailwindcss": "^0.6.8",


### PR DESCRIPTION
## Summary

- **Markdown linting** (`markdownlint-cli2`): covers all 23 `.md` files across the repo — the one file type previously unguarded. Runs on pre-commit (lint-staged), in the npm `lint` script, and in CI.
- **VS Code extensions**: added `astro-build.astro-vscode`, `dbaeumer.vscode-eslint`, `esbenp.prettier-vscode`, `stylelint.vscode-stylelint`, `DavidAnson.vscode-markdownlint` to `.vscode/extensions.json` (only Tailwind was recommended before).
- **VS Code settings**: `format-on-save`, Prettier as default formatter, ESLint validation for `.astro`/`.ts`/`.js`, Stylelint validation for `.css`.
- **`.editorconfig`**: universal cross-editor consistency (UTF-8, LF, 2-space indent, final newline).
- **Pre-existing issues fixed**: auto-fixed markdown style across `docs/` and root files; fixed 4 fenced code blocks missing language spec and 1 bold-used-as-heading.

## What's already great (unchanged)

ESLint (flat config) + `eslint-plugin-astro` + `typescript-eslint`, Stylelint + standard config, Prettier + Astro/Tailwind plugins, Husky + lint-staged, yamllint in CI, `astro check` — all intact.

## Test plan

- [ ] CI passes on this PR
- [ ] `npm run lint` in `site/` exits 0
- [ ] `markdownlint-cli2` (no args) from repo root exits 0
- [ ] VS Code: install recommended extensions → save any `.astro` file → auto-formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)