### PR TITLE
docs: add delivery automation docs and update contributing guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,83 @@
+# Copilot instructions
+
+You are the **simple-AI lane** for this repository. You handle straightforward,
+fully-specified implementation tasks. If a task seems ambiguous or requires reading
+many files, ask for clarification rather than guessing.
+
+---
+
+## Branch naming (required)
+
+All branches must follow this pattern:
+
+```
+task/<issue-number>-<short-slug>
+```
+
+Examples: `task/42-fix-hero-overflow`, `task/57-apply-contact-copy`
+
+**PR target:** always `epic/<number>-<slug>` (the parent epic branch).
+If there is no epic branch, target `dev`.
+
+Never push directly to `dev` or `main`.
+
+---
+
+## Label reference
+
+| Label | Meaning |
+|-------|---------|
+| `owner:simple-ai` | This task is assigned to you |
+| `owner:agentic-ai` | Claude lane — not your task |
+| `task:feat` | Feature implementation |
+| `task:bug-fix` | Bug fix |
+| `task:decision` | Human decision needed — do not implement |
+| `automation:started` | Applied when execution begins |
+
+---
+
+## Commit format
+
+Use conventional commits:
+
+```
+feat: add booking button to contact page
+fix: correct mobile overflow on hero section
+chore: update .pages.yml tags field
+docs: add Vercel comment walkthrough
+```
+
+---
+
+## Repo layout
+
+```
+professional_site/
+├── site/           ← Astro website (all code changes go here)
+│   ├── src/
+│   │   ├── content/    ← CMS content (projects, writing, testimonials, settings)
+│   │   ├── components/ ← Astro components
+│   │   └── pages/      ← Astro pages
+│   └── public/media/   ← uploaded images
+├── docs/           ← documentation
+└── .github/        ← workflows and templates
+```
+
+## Tech stack
+
+- **Framework:** Astro 6 + Tailwind CSS
+- **Content:** Pages CMS (git-backed; files in `site/src/content/`)
+- **Linting:** ESLint, stylelint, Prettier, markdownlint (run `npm run lint` in `site/`)
+- **Build:** `npm run build` in `site/`
+
+Run `npm run lint` before committing. The pre-commit hook runs lint-staged automatically.
+
+---
+
+## What you should NOT do
+
+- Do not push to `dev` or `main`
+- Do not modify `.github/workflows/` unless the task explicitly says to
+- Do not change `.pages.yml` without understanding the CMS schema
+- Do not introduce secrets or credentials into code
+- Do not create new files unless the task requires it — prefer editing existing files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,10 +259,15 @@ npm run lint:fix  # fix and format in-place
 
 ### Branch model
 
-- **Feature/fix branches** are created from `dev`, named `feat/<description>` or `fix/<description>`
-- **PRs target `dev`** (not `main`)
-- **Release PRs** go from `dev` → `main` when ready to deploy to GitHub Pages
+| Branch | Targets | Purpose |
+|--------|---------|---------|
+| `task/<N>-<slug>` | `epic/<N>-<slug>` (or `dev`) | Single task |
+| `epic/<N>-<slug>` | `dev` | Group of related tasks |
+| `dev` | `main` | Release PR |
+
+- Branch names are enforced by `branch-name-check.yml` — non-conforming branches will fail CI
 - Never force-push `dev` or `main`
+- Issues are closed automatically when their branch merges (`close-task-on-merge.yml`)
 
 ### Commit format
 
@@ -316,15 +321,21 @@ Only team members (Vercel accounts with access to the project) can convert comme
 | Doc | What it covers |
 |-----|---------------|
 | [docs/ci.md](docs/ci.md) | CI jobs, triggers, branch protection setup |
-| [docs/issue-labels.md](docs/issue-labels.md) | Label taxonomy, epic/task structure, executor labels |
-| [docs/project-management.md](docs/project-management.md) | Issue workflow, Vercel → GitHub issue → Claude automation |
+| [docs/issue-labels.md](docs/issue-labels.md) | Label taxonomy: source, task-kind, owner, automation state |
+| [docs/ai-workflows.md](docs/ai-workflows.md) | Lanes, planner policy, routing rules, unblocker behavior |
+| [docs/project-management.md](docs/project-management.md) | Issue flow, board conventions, branch model |
+| [docs/github-project-board.md](docs/github-project-board.md) | Board setup, Status field, views |
 | [CLAUDE.md](CLAUDE.md) | AI autonomy config and hard limits |
 
 ---
 
 ## AI
 
-This section is for AI agents (Claude Code and similar) working inside this repository. The canonical autonomy config is in [CLAUDE.md](CLAUDE.md). What follows is a structured summary of the workflow and expectations.
+This section is for AI agents (Claude Code, Copilot, and similar) working inside this
+repository. The canonical autonomy config is in [CLAUDE.md](CLAUDE.md). What follows is
+a structured summary of the workflow and expectations.
+
+See also: [docs/ai-workflows.md](docs/ai-workflows.md) for the full operating model.
 
 ### Scope
 
@@ -335,7 +346,7 @@ All autonomous actions are sandboxed to `c:/Users/raino/GitHub/professional_site
 - Read, create, edit, or delete any file inside this repository
 - Create and switch git branches
 - Commit and push branches to `origin`
-- Open PRs via `gh pr create` targeting `dev`
+- Open PRs via `gh pr create`
 - Merge PRs with `gh pr merge <number> --auto --merge`
 - Install repo-local dependencies (`node_modules/`, etc.)
 - Run build, lint, format, and test commands
@@ -355,41 +366,59 @@ All autonomous actions are sandboxed to `c:/Users/raino/GitHub/professional_site
 
 | Layer | Tool |
 |-------|------|
-| Framework | Astro (static-site generator) |
+| Framework | Astro 6 (static-site generator) |
 | Styling | Tailwind CSS |
 | CMS | Pages CMS (git-backed; config in `.pages.yml`) |
 | Production hosting | GitHub Pages (deploys from `main`) |
-| Preview hosting | Vercel (production branch = `dev`; public alias at `https://profesional-site.vercel.app`; per-PR hash URLs have the comment toolbar) |
+| Preview hosting | Vercel (tracks `dev`; public at `https://profesional-site.vercel.app`) |
 
-### Git workflow
+### Branch and PR conventions
 
-1. Check existing branches before starting: `git branch -a`
-2. Create a feature branch from `dev`: `git checkout -b feat/<description>`
-3. Commit with conventional format: `feat:`, `fix:`, `chore:`, `docs:`
-4. Push and open a PR targeting `dev`: `gh pr create --base dev`
-5. Merge with: `gh pr merge <number> --auto --merge`
-6. Do not open PRs targeting `main` — that is the release branch, managed by the human developer
+| Branch | Targets | Example |
+|--------|---------|---------|
+| `task/<N>-<slug>` | `epic/<N>-<slug>` (or `dev`) | `task/42-fix-hero-overflow` |
+| `epic/<N>-<slug>` | `dev` | `epic/31-homepage-refresh` |
+| `dev` | `main` | release PR |
+
+- Branch names are enforced — non-conforming branches fail the `branch-name-check` CI job
+- Issues close automatically when their branch merges (`close-task-on-merge.yml`)
+- Always merge with: `gh pr merge <number> --auto --merge`
 
 ### Automated issue-to-PR workflow
 
-The GitHub Action `claude-agent.yml` triggers Claude to implement issues automatically:
+```
+automation:plan label added → planner workflow runs → automation:planned applied
+→ (blockers clear) → claude-ready added (or @claude comment) → Claude opens PR
+→ PR merges into epic/* → issue closes automatically
+```
 
-| Label combination | What happens |
-|------------------|-------------|
-| `simple-ai` + `claude-ready` | Action runs with `max_turns: 5` (fast model config) |
-| `agentic-ai` + `claude-ready` | Action runs with `max_turns: 20` (full agentic config) |
-| Comment contains `@claude <instruction>` | Action runs with simple config regardless of labels |
+| Trigger | What happens |
+|---------|-------------|
+| `automation:plan` label added | Planner workflow runs; shapes the issue |
+| `claude-ready` label added | Claude workflow runs (approval gate) |
+| `@claude <instruction>` comment | Claude workflow runs immediately |
 
-**Label meanings:**
+**Label taxonomy:**
 
 | Label | Meaning |
 |-------|---------|
-| `simple-ai` | Narrow, well-scoped change — a clear PR description could be written in advance |
-| `agentic-ai` | Multi-step, requires reading codebase and docs, may touch many files |
-| `human-dev` | Needs a human: secrets, infra, architectural judgment |
-| `needs-site-owner` | Blocked until Agreni provides content, copy, or a decision |
-| `claude-ready` | Human-approved gate — triggers the Action when added |
-| `from-vercel` | Issue was created via Vercel's "Convert to GitHub Issue" button |
+| `owner:simple-ai` | Copilot lane — fully specced, small task |
+| `owner:agentic-ai` | Claude lane — multi-step, needs codebase reasoning |
+| `owner:human-dev` | Human developer lane |
+| `owner:site-owner` | Site owner (Agreni) lane |
+| `task:feat` / `task:bug-fix` / `task:decision` / `task:content` | Kind of work |
+| `source:human` / `source:vercel` / `source:cms` | Where the issue came from |
+| `automation:plan` → `automation:planned` → `automation:started` | Automation state |
+| `claude-ready` | Human approval gate (temporary; will be removed once system is trusted) |
+
+### Pages CMS content flow
+
+Agreni edits content in Pages CMS. Her changes commit directly to `dev` — no PR,
+no issue, no CI. Vercel detects the push and rebuilds `profesional-site.vercel.app`
+automatically. This is the correct behavior: content bypasses the task/epic/PR pipeline.
+
+Do not create issues for CMS content changes unless Agreni explicitly asks for
+developer help.
 
 ### CMS content model
 
@@ -406,20 +435,20 @@ Media files are stored in `site/public/media/`.
 
 ### CI pipeline
 
-CI runs on PRs targeting `main` and on pushes to `main`. Jobs in order:
+CI runs on PRs targeting `dev` or `main`, and on pushes to `main`. Jobs in order:
 
 1. `lint` — YAML lint, ESLint, stylelint, Prettier
-2. `astro-check` — Astro type/diagnostic check (requires `lint`)
-3. `build` — Astro production build (requires `astro-check`)
-4. `deploy` — GitHub Pages deploy (only on `main`, requires `build`)
+2. `astro-check` — Astro type/diagnostic check
+3. `build` — Astro production build
+4. `deploy` — GitHub Pages deploy (only on `main`)
 
-All three non-deploy jobs must pass before a PR can merge into `main`. See [docs/ci.md](docs/ci.md) for details.
+See [docs/ci.md](docs/ci.md) for details.
 
 ### Notes for agents
 
-- Always check existing branches before starting new work (`git branch -a`)
-- `git pull --all` can error even when tracking is set — use `git pull` or set upstream explicitly
-- The `dev` branch is the integration branch; all feature PRs target `dev`
-- Do not attempt to build the `notesToDevTeam` CMS field or `cms-notes-to-issues.yml` — this feature was abandoned (issues #30, #38, #19 are closed)
-- The site owner (Agreni) is non-technical; any content-related issues labeled `needs-site-owner` are blocked until she provides input — do not fabricate placeholder content for production fields
-- `ANTHROPIC_API_KEY` must be set in GitHub repo secrets for `claude-agent.yml` to work; adding or rotating secrets is a human task
+- Always check existing branches before starting: `git branch -a`
+- `git pull --all` can error even when tracking is set — use `git pull`
+- The `dev` branch is the integration branch; epic PRs target `dev`
+- Do not attempt to build the `notesToDevTeam` CMS field — abandoned (issues #30, #38, #19 closed)
+- The site owner (Agreni) is non-technical; `owner:site-owner` issues are blocked until she acts — never fabricate placeholder content for production fields
+- `ANTHROPIC_API_KEY` must be set in GitHub repo secrets for `planner.yml` and `claude.yml` to work; adding secrets is a human task (#78)

--- a/docs/ai-workflows.md
+++ b/docs/ai-workflows.md
@@ -1,0 +1,206 @@
+# AI workflows and delivery automation
+
+This document describes how work flows through this repository: from issue creation to
+planning, execution, unblocking, and deployment.
+
+---
+
+## Work lanes
+
+There are five lanes. Every issue is assigned to exactly one.
+
+| Lane | Label | Who | When to use |
+|------|-------|-----|-------------|
+| **Planner** | *(no owner label — planner is a meta-lane)* | Claude (planner workflow) | Shapes incoming issues into executable tasks |
+| **Simple AI** | `owner:simple-ai` | GitHub Copilot coding agent | Fully specced, small, unambiguous tasks |
+| **Agentic AI** | `owner:agentic-ai` | Claude Code Action | Scoped but multi-file or needs reasoning |
+| **Human dev** | `owner:human-dev` | Human developer | Architectural, risky, secrets/infra, high judgment |
+| **Site owner** | `owner:site-owner` | Agreni | Content, copy, decisions, approvals |
+
+---
+
+## Label taxonomy
+
+Every issue should have exactly one label from each applicable group:
+
+### Source labels — where did this issue come from?
+| Label | Meaning |
+|-------|---------|
+| `source:human` | Opened directly by a human in GitHub |
+| `source:vercel` | Created via Vercel's "Convert to GitHub Issue" button |
+| `source:cms` | Originated from CMS content (reserved for future use) |
+
+### Task-kind labels — what kind of work is this?
+| Label | Meaning |
+|-------|---------|
+| `type:epic` | Parent deliverable; has child task issues |
+| `task:feat` | Feature implementation |
+| `task:bug-fix` | Bug fix |
+| `task:decision` | A tracked human decision that blocks other work |
+| `task:content` | Content entry or editing |
+
+### Owner labels — who executes this?
+| Label | Meaning |
+|-------|---------|
+| `owner:simple-ai` | Copilot; task is fully specced and small |
+| `owner:agentic-ai` | Claude; task needs reasoning or reads multiple files |
+| `owner:human-dev` | Human developer |
+| `owner:site-owner` | Site owner (Agreni) |
+
+### Automation state labels
+| Label | Meaning |
+|-------|---------|
+| `automation:plan` | Triggers the planner workflow |
+| `automation:planned` | Planner has shaped this issue |
+| `automation:started` | AI execution is underway |
+
+### Approval gate
+| Label | Meaning |
+|-------|---------|
+| `claude-ready` | Human has approved this issue for Claude to execute automatically |
+
+> **Note:** `claude-ready` is a temporary gate. Once the system is trusted, it will be
+> removed so that Claude auto-starts when the unblocker releases a task. To remove it,
+> delete the `issues: labeled` trigger block in `.github/workflows/claude.yml`.
+
+---
+
+## Work sources
+
+Issues come from three places:
+
+| Source | Flow |
+|--------|------|
+| **Vercel preview comments** | Agreni leaves a comment on the preview → clicks "Create GitHub Issue" in Vercel → issue created with `source:vercel` |
+| **Human-opened GitHub issues** | Developer or site owner opens an issue directly → add `source:human` |
+| **CMS** | Reserved; not currently active |
+
+---
+
+## The planner
+
+The planner is an AI that shapes incoming issues. It never writes code.
+
+### Trigger
+Add the `automation:plan` label to any issue.
+
+### What the planner does
+It reads the issue and chooses one of four paths:
+
+**Path A — Clear single task**
+The issue is concrete. Planner adds `source:*`, `task:*`, `owner:*` labels,
+removes `automation:plan`, adds `automation:planned`.
+
+**Path B — Multi-step work (epic)**
+The issue needs multiple PRs. Planner labels the parent `type:epic`, creates child
+issues (each with one `source:*`, `task:*`, `owner:*`), sets blocking relationships,
+and adds `automation:planned` to the parent.
+
+**Path C — Small ambiguity**
+A small piece of information is missing. Planner asks in comments.
+A maintainer re-adds `automation:plan` once the question is answered.
+
+**Path D — Decision task**
+The missing information is a substantial blocker. Planner creates a child
+`task:decision` issue assigned to the appropriate owner, sets it as a dependency,
+and marks the parent `automation:planned`.
+
+### Clarification policy
+- Use **Path C** (comment) when the missing information is small: which URL, which font,
+  is this copy approved?
+- Use **Path D** (decision task) when the decision blocks multiple tasks, may not happen
+  soon, or belongs to a specific owner who needs to track it.
+
+---
+
+## Routing rules by task kind
+
+| Task kind | Can be routed to |
+|-----------|-----------------|
+| `task:feat` | `owner:simple-ai`, `owner:agentic-ai`, `owner:human-dev` |
+| `task:bug-fix` | `owner:simple-ai`, `owner:agentic-ai`, `owner:human-dev` |
+| `task:decision` | `owner:site-owner`, `owner:human-dev` |
+| `task:content` | `owner:site-owner`; sometimes `owner:simple-ai`/`owner:agentic-ai` if applying already-approved content |
+
+**Simple AI routing rule**: only route to `owner:simple-ai` if the task is completely
+specified. Copilot works from the issue text as written; additional clarification goes
+on the PR it raises, not the issue.
+
+---
+
+## Pages CMS — the site owner content lane
+
+Agreni edits content in Pages CMS (app.pagescms.org). Pages CMS commits directly to
+`dev` — no PR, no branch, no CI check. This is intentional.
+
+```
+Agreni saves in Pages CMS → direct commit to dev → Vercel detects push
+→ profesional-site.vercel.app rebuilds automatically
+```
+
+CMS commits bypass the task/epic/PR delivery pipeline entirely. Content is the
+`owner:site-owner` lane and does not need code review.
+
+> **If the preview stops updating after a CMS save:** check that the Pages CMS app
+> (app.pagescms.org) is still configured to target the `dev` branch. This is set in
+> the Pages CMS project settings, not in `.pages.yml`.
+
+---
+
+## Automation workflows
+
+Five workflows handle the full lifecycle. All logic is inlined in the YAML — no external scripts.
+
+| Workflow | File | Trigger | Purpose |
+|----------|------|---------|---------|
+| **Planner** | `planner.yml` | `automation:plan` label added | Shapes issues into executable tasks |
+| **Claude** | `claude.yml` | `claude-ready` label OR `@claude` comment | Executes agentic-AI tasks |
+| **Branch name check** | `branch-name-check.yml` | PR opened/updated | Enforces branch naming convention |
+| **Close task on merge** | `close-task-on-merge.yml` | PR merged | Auto-closes issues from branch name |
+| **Unblocker** | `unblocker.yml` | Issue closed | Releases newly unblocked dependent issues |
+
+### Unblocker behavior
+
+When any issue closes, the unblocker:
+1. Finds issues that were blocked by the closed issue (via GraphQL `trackedByIssues`,
+   with fallback to scanning issue bodies for `Blocked by #N` text).
+2. For each candidate, checks if all its blockers are now closed.
+3. If fully unblocked:
+   - Posts a comment saying the issue is now **Ready**.
+   - If `owner:agentic-ai` + `claude-ready`: posts `@claude` to trigger execution.
+   - If `owner:simple-ai`, `owner:human-dev`, `owner:site-owner`: leaves at Ready.
+
+---
+
+## End-to-end examples
+
+### Vercel comment → single bug fix → merged
+
+1. Agreni comments on Vercel preview.
+2. Comment is converted to GitHub issue (Vercel GitHub Issues integration).
+3. Maintainer adds `automation:plan`.
+4. Planner labels it `source:vercel`, `task:bug-fix`, `owner:simple-ai`, `automation:planned`.
+5. Maintainer adds `claude-ready` (or assigns to Copilot).
+6. Claude/Copilot opens PR on `task/<N>-<slug>` targeting `epic/*`.
+7. PR merges → `close-task-on-merge` closes the issue.
+8. `unblocker` checks for newly unblocked dependents.
+
+### Human epic → decision blocks implementation
+
+1. Developer opens "Epic: homepage refresh".
+2. Maintainer adds `automation:plan`.
+3. Planner creates:
+   - `task:decision` "Approve final hero copy" → `owner:site-owner`
+   - `task:feat` "Implement hero section" → `owner:agentic-ai` (blocked by decision)
+4. Agreni resolves the copy decision and closes the decision issue.
+5. `unblocker` releases the hero implementation task.
+6. Maintainer adds `claude-ready`; Claude starts working.
+
+---
+
+## Prerequisites for full automation
+
+| Prerequisite | Status | Issue |
+|-------------|--------|-------|
+| `ANTHROPIC_API_KEY` secret in GitHub Actions | Required for planner.yml and claude.yml | #78 |
+| Vercel GitHub Issues integration installed | Required for source:vercel flow | #83 |

--- a/docs/github-project-board.md
+++ b/docs/github-project-board.md
@@ -1,0 +1,125 @@
+# GitHub Project board
+
+This document describes how the GitHub Project board is configured, what the Status
+field means, and how workflows move issues through it.
+
+The project is at: [github.com/users/rainonej/projects](https://github.com/users/rainonej/projects)
+
+---
+
+## Status field
+
+The board uses a single **Status** field with these values:
+
+| Status | Meaning | Set when |
+|--------|---------|----------|
+| **Inbox** | New issue, not yet planned | Issue is created (auto-add automation) |
+| **Planned** | Planner has shaped this issue | `automation:planned` label is applied |
+| **Blocked** | Has one or more open dependencies | Blocking relationship exists |
+| **Ready** | No open blockers; work may begin | Last blocker closes (unblocker runs) |
+| **In Progress** | Work has actually started | AI execution begins or human picks it up |
+| **In Review** | A PR exists and is open | PR is opened |
+| **Done** | Issue is closed | Issue closes (`close-task-on-merge` or manually) |
+
+---
+
+## Required board views
+
+| View | Filter | Purpose |
+|------|--------|---------|
+| **Main Board** | *(all issues)* grouped by Status | Operational overview |
+| **Epic View** | `label:type:epic` | All parent deliverables |
+| **Decision View** | `label:task:decision` | Tracked human decisions blocking work |
+| **AI Queue** | `label:owner:simple-ai,owner:agentic-ai` | Issues ready for AI execution |
+| **Human Queue** | `label:owner:human-dev,owner:site-owner` | Issues needing human action |
+
+---
+
+## Branch model
+
+```
+task/<number>-<slug>  →  epic/<number>-<slug>  →  dev  →  main
+```
+
+| PR type | Head branch | Target branch |
+|---------|-------------|---------------|
+| Task PR | `task/<N>-<slug>` | `epic/<N>-<slug>` (or `dev` for standalone) |
+| Epic PR | `epic/<N>-<slug>` | `dev` |
+| Release PR | `dev` | `main` |
+
+Branch names are enforced by `branch-name-check.yml` on every PR.
+
+---
+
+## PR targets and issue auto-close
+
+GitHub only auto-closes issues for PRs merging into the **default branch**. Since
+task PRs target `epic/*` (not the default), we use `close-task-on-merge.yml`:
+
+- `task/<N>-*` merged into `epic/*` → closes issue #N
+- `epic/<N>-*` merged into `dev` → closes issue #N
+- `dev` → `main` (release PR) → no issue to close; this is a deployment event
+
+---
+
+## Blockers and dependencies
+
+Use GitHub's native **sub-issues** and **issue dependencies**:
+
+- **Sub-issues**: epic → child task hierarchy (Relationships sidebar → Sub-issues)
+- **Blocking**: task B is blocked by task A (Relationships sidebar → Blocked by)
+
+When a blocking issue closes, `unblocker.yml` runs and releases newly unblocked issues.
+
+**Good blockers:**
+- Final copy must be approved before implementation
+- Task B depends on Task A's refactor landing first
+- A scope decision must happen before work starts
+
+**Not blockers:**
+- Things that could proceed independently
+- Vague "probably related" relationships
+- Approvals not actually on the critical path
+
+---
+
+## How workflows move issues
+
+| Event | Workflow | Board effect |
+|-------|----------|-------------|
+| Issue created | *(GitHub auto-add)* | Inbox |
+| `automation:planned` label applied | planner.yml | Inbox → Planned |
+| Blocking relationship added | *(manual)* | Planned → Blocked |
+| Last blocker closes | unblocker.yml | Blocked → Ready |
+| `claude-ready` label added or `@claude` comment | claude.yml | Ready → In Progress |
+| PR opened | *(GitHub native)* | In Progress → In Review |
+| `task/*` PR merged into `epic/*` | close-task-on-merge.yml | In Review → Done |
+| `epic/*` PR merged into `dev` | close-task-on-merge.yml | In Review → Done |
+
+> **Note:** Status field updates (e.g. Blocked → Ready) are performed by `unblocker.yml`
+> via the GitHub Projects GraphQL API. The other transitions above may need to be set
+> manually or via additional GitHub Projects automations configured in the UI.
+
+---
+
+## GitHub Project automations (built-in)
+
+Configure these in the project Settings → Workflows:
+
+| Automation | Setting |
+|------------|---------|
+| Auto-add issues from repo | On — adds new issues as Inbox |
+| Item closed → Done | On |
+| Pull request merged → Done | On |
+
+---
+
+## One-time setup checklist
+
+- [ ] Status field has all 7 values: Inbox, Planned, Blocked, Ready, In Progress, In Review, Done
+- [ ] Main Board view grouped by Status
+- [ ] Epic View with filter `label:type:epic`
+- [ ] Decision View with filter `label:task:decision`
+- [ ] AI Queue with filter `label:owner:simple-ai,owner:agentic-ai` (or two separate labels)
+- [ ] Human Queue with filter `label:owner:human-dev,owner:site-owner`
+- [ ] Auto-add automation enabled for this repository

--- a/docs/issue-labels.md
+++ b/docs/issue-labels.md
@@ -1,143 +1,90 @@
-# Issue label system (proposal)
+# Issue labels
 
-Labels answer: **who can execute this work?** Multiple labels per issue are allowed when a ticket needs more than one kind of contributor.
+Labels encode four things about every issue: where it came from, what kind of work it
+is, who executes it, and what automation state it's in.
 
----
-
-## Labels vs tags, and select-one vs select-many
-
-**In GitHub there are only labels.** (What people often call "tags" are just labels.) Every label is **multi-select**: you can add as many labels to an issue as you want. GitHub does not support "pick exactly one from this set" in the UI.
-
-So the useful distinction is how we **design** each label set:
-
-| Kind | Meaning | Example | Fits GitHub? |
-|------|--------|--------|--------------|
-| **Select all that apply** | Multiple labels from the set can apply to one issue. | "This needs the site owner *and* then agentic AI to implement." | Yes — native. |
-| **At most one** | Only one label from the set should apply (e.g. one priority). | "This is P0" (not also P1). | Yes, but only by convention: we document "use at most one priority label" and rely on discipline (or a bot). GitHub won't enforce it. |
-
-**This proposal uses only "select all that apply"** for the executor set at the **parent** level. For **child** issues we use **exactly one** executor label each (see Parent/child structure below).
+Every issue should have exactly one label from each applicable group below.
 
 ---
 
-## Parent/child structure (epics and deliverables)
+## Source labels
 
-- **Parent issue** = one **deliverable** from a product manager’s perspective: the outcome of a sprint, the thing end users (or the site owner) actually get. E.g. “Booking and contact work,” “Site reflects Agreni’s positioning.”
-- **Child issues** = tasks; title is a **task name only** (e.g. "Implement blog, testimonials, singleton pages, CMS config"), **not** "Epic N: …". Each child has **exactly one** executor label. If a piece of work needs two executor types (e.g. site owner provides copy *and* agentic AI implements), split it into two children.
-- **Parent labels** = **epic** plus the union of its children’s executor labels. Use **Blocking** (issue dependencies) so tasks show "Blocked by" / "Blocking" in the Relationships sidebar; API: `POST .../issues/{n}/dependencies/blocked_by` with `{"issue_id": <blocker id>}`. See `docs/epic-briefs.md` for epic body template and `docs/github-project-views.md` for project views (Epics, Unblocked tasks, Unblocked but blocking others).
-
-**Linking:**
-
-- Use GitHub's **Sub-Issues API** so the Relationships sidebar shows the parent (see Summary). In the parent body, keep a task list e.g. `- [ ] #14`. When a child is closed, check the box (or use “closes” in the child’s PR).
-- In each **child** issue body: `**Parent:** #N` (link to the parent).
-
-**Rule:** Every child has **exactly one** executor label. Split work so that each sub-issue is clearly one type (simple-ai, agentic-ai, human-dev, or needs-site-owner).
-
----
-
-## Executor labels (who does the work)
-
-**On children:** **Exactly one** per child. **On parents:** **All** labels that any of its children have (union).
-
-| Label | Color | Meaning | When to use |
-|-------|--------|--------|-------------|
-| **simple-ai** | `#0E8A16` (green) | Straightforward, narrow-scope implementation. Also signals: use a faster/cheaper model config when `claude-ready` is added. | Add a script to CI, expand a config list, apply a documented code change. |
-| **agentic-ai** | `#1D76DB` (blue) | Multi-step, codebase-wide, or needs exploration. Also signals: use a full agentic model config (higher max-turns) when `claude-ready` is added. | Migrate to one CMS spine, add content collections + routes, implement from audit report. |
-| **human-dev** | `#F9D0C4` (peach) or `#FBCA04` (yellow) | Needs human developer: judgment, security, infra, or complex debugging. | Preview deploy setup, auth/credentials, performance investigation, architectural decisions. |
-| **needs-site-owner** | `#C5DEF5` (light blue) or `#D93F0B` (red) | Needs the site/product owner: content, copy, positioning, or product/priority decisions. | Replace placeholder copy, choose booking URL, approve IA, provide testimonials or blog content. |
-
-### Rules of thumb
-
-- **simple-ai**: “A clear PR description could be written and a capable AI could implement it without opening 10 files.”
-- **agentic-ai**: “Requires reading the codebase, docs, and maybe the audit; might touch many files or have ambiguous steps.”
-- **human-dev**: “Involves secrets, deploy config, or decisions we don’t want to automate.”
-- **needs-site-owner**: “Blocked until the site owner provides content, a decision, or a preference.”
-
----
-
-## Automation trigger labels
-
-These labels control automated workflows, not executor assignment.
-
-| Label | Color | Role | Meaning |
-|-------|-------|------|---------|
-| **claude-ready** | `#5319E7` (purple) | Approval gate | A human has reviewed this issue and approved it for Claude to implement automatically. Adding this label to a `simple-ai` or `agentic-ai` issue triggers `claude-agent.yml`. |
-| **from-vercel** | `#0075CA` (blue) | Source tag | Issue was created via Vercel's “Convert to GitHub Issue” button on a preview comment. |
-
-**Flow:** Issue is created with `simple-ai` or `agentic-ai` (complexity/model) → human reviews and adds `claude-ready` (approval) → GitHub Action fires with the appropriate config.
-
-**`@claude` shortcut:** Commenting `@claude <instruction>` on any issue also triggers the action (uses the simple config regardless of labels).
-
-## Optional: spec clarity (if you want to track “AI ready”)
+Where did this issue originate?
 
 | Label | Meaning |
-|-------|--------|
-| **spec: complete** | Acceptance criteria and scope are clear enough for an AI or junior dev to execute. |
-| **spec: draft** | Direction is set but details need refinement before implementation. |
-
-Use these only if you find it useful to filter “ready to implement” vs “needs more spec.”
-
----
-
-## Parent deliverables and children (mapping)
-
-Each row is one **parent** (deliverable). Children are split so each has **exactly one** executor label. Parent gets the **union** of its children’s labels.
-
-| Parent (deliverable) | Children (each exactly one label) | Parent labels |
-|----------------------|-----------------------------------|---------------|
-| **Single CMS path** | Choose CMS spine and remove conflicting artifacts → agentic-ai | agentic-ai |
-| **Site reflects positioning** | (1) Site owner provides positioning and copy → needs-site-owner; (2) Implement brand and IA changes → agentic-ai | needs-site-owner, agentic-ai |
-| **Blog, testimonials, richer settings** | (1) Implement blog, testimonials, singleton pages, CMS config → agentic-ai; (2) Content for blog/testimonials → needs-site-owner | agentic-ai, needs-site-owner |
-| **Type-safe content and no placeholders** | (1) Content schemas and refactor → agentic-ai; (2) Replace placeholder copy and booking URL → needs-site-owner | agentic-ai, needs-site-owner |
-| **Editor help and guidance** | Add help text and document single editor path → simple-ai (or agentic-ai if multi-file) | simple-ai |
-| **Editor notes become issues** | (1) Schema + workflow (no secrets) → agentic-ai; (2) Token/secret setup if needed → human-dev | agentic-ai, human-dev |
-| **CI complete and PR previews** | (1) Add astro check to CI → simple-ai; (2) Preview deploys and branch protection → human-dev | simple-ai, human-dev |
-| **Booking and contact work** | (1) Wire booking URL from settings to components → simple-ai; (2) Site owner provides real booking URL → needs-site-owner | simple-ai, needs-site-owner |
-| **Writing and collaboration in nav** | Nav/layout changes for writing-first UX → agentic-ai | agentic-ai |
-| **Documentation and launch content** | (1) Docs structure and for-agreni pack → agentic-ai; (2) Launch content (site owner) → needs-site-owner | agentic-ai, needs-site-owner |
+|-------|---------|
+| `source:human` | Opened directly by a human in GitHub |
+| `source:vercel` | Created via Vercel's "Convert to GitHub Issue" button on a preview comment |
+| `source:cms` | Originated from CMS content (reserved for future use) |
 
 ---
 
-## Suggested mapping for current epics (legacy reference)
+## Task-kind labels
 
-| Epic | Focus | Becomes children with exactly one label each |
-|------|--------|-----------------------------------------------|
-| 0 | Choose one CMS spine + remove conflict | One child: agentic-ai |
-| 1 | Reposition brand language and IA | Two children: needs-site-owner + agentic-ai |
-| 2 | Singleton pages, blog, testimonials, richer settings | Two children: agentic-ai + needs-site-owner |
-| 3 | Content schemas + hardcode cleanup | Two children: agentic-ai + needs-site-owner |
-| 4 | Editor UX and labels/help text | One child: simple-ai or agentic-ai |
-| 5 | Automation notes_to_dev_team → issues | Two children: agentic-ai + human-dev (if secrets) |
-| 6 | CI completeness + preview deploys | Two children: simple-ai + human-dev |
-| 7 | Booking/contact consolidation | Two children: simple-ai + needs-site-owner |
-| 8 | Nav/layout writing-first collaboration UX | One child: agentic-ai |
-| 9–10 | Docs + launch content production | Two children: agentic-ai + needs-site-owner |
+What kind of work is this?
+
+| Label | Meaning |
+|-------|---------|
+| `type:epic` | Parent deliverable with child task issues |
+| `task:feat` | Feature implementation |
+| `task:bug-fix` | Bug fix |
+| `task:decision` | A tracked human decision that blocks other work |
+| `task:content` | Content entry or editing |
+
+**Epics vs tasks:** A `type:epic` issue is the parent. Its children are individual tasks,
+each with exactly one `task:*` label and one `owner:*` label. Split work so that each
+child is clearly one type — if a task needs the site owner to provide copy *and* an
+AI to implement it, those are two separate child issues.
 
 ---
 
-## Summary
+## Owner labels
 
-- **Parent** = one deliverable (PM view; what users get). **Child** = one work item with **exactly one** executor label. Parent has **task list of children** and **union of children’s labels**.
-- **Four executor labels**: `simple-ai`, `agentic-ai`, `human-dev`, `needs-site-owner`. On children: exactly one. On parents: all that apply across children.
-- **Optional**: `spec: complete` / `spec: draft` for spec readiness.
-- Linking: parent body lists `- [ ] #N` for each child; each child body has `**Parent:** #M`.
+Who executes this issue?
 
-**Labels:** Create the four executor labels (e.g. via GitHub UI or `gh api` as repo owner). Apply exactly one to each child and the union to each parent. Use the **rainonej** account for `gh` when creating labels or sub-issues on this repo (owner has permission; other accounts may get 404).
+| Label | Meaning | When to use |
+|-------|---------|-------------|
+| `owner:simple-ai` | GitHub Copilot coding agent | Fully specced, small, unambiguous. A clear PR description is all it needs. |
+| `owner:agentic-ai` | Claude Code Action | Scoped but multi-file, needs codebase exploration, or benefits from reasoning. |
+| `owner:human-dev` | Human developer | Architectural decisions, secrets/infra, security, complex debugging. |
+| `owner:site-owner` | Agreni (site/product owner) | Content, copy, positioning, product decisions, approvals. |
 
-**Epic body (human-readable):** Each parent should have a rich body: Goal, Context, Success criteria, Scope, Out of scope, Children (task list), Notes for agent. See `docs/epic-briefs.md` for the template and full text. Written so a human can hand the epic to an agent, who then splits into tasks, assigns one label per task, and sets blocking relationships.
+**Rule for simple-ai:** Only route to `owner:simple-ai` if the task is completely
+specified. Copilot works from the issue text as written; new requirements go on the PR.
 
-**Views:** To see all epics, unblocked tasks, and unblocked tasks that block others, use a GitHub Project with multiple views. See `docs/github-project-views.md`.
+**Rule for epics:** Each child gets exactly one `owner:*`. The parent gets the union of
+all its children's owner labels.
 
-**Current parent/child issue numbers (as created):**
+---
 
-| Parent (Epic:) | #  | Children | Blocking (B blocked by A) |
-|----------------|----|----------|----------------------------|
-| Single CMS path | 25 | #14 | — |
-| Site reflects positioning | 26 | #18, #35 | #18 by #35 |
-| Blog, testimonials, richer settings | 28 | #15, #36 | #36 by #15 |
-| Type-safe content and no placeholders | 27 | #16, #37 | #37 by #16 |
-| Editor help and guidance | 29 | #17 | — |
-| Editor notes become issues | 30 | #19, #38 | #38 by #19 |
-| CI complete and PR previews | 31 | #20, #39 | #39 by #20 |
-| Booking and contact work | 33 | #21, #40 | #21 by #40 |
-| Writing and collaboration in nav | 32 | #22 | — |
-| Documentation and launch content | 34 | #23, #41 | #41 by #23 |
+## Automation state labels
+
+What stage is this issue in?
+
+| Label | Meaning |
+|-------|---------|
+| `automation:plan` | Added by a maintainer to trigger the planner workflow |
+| `automation:planned` | Planner has finished shaping this issue |
+| `automation:started` | AI execution is currently underway |
+
+---
+
+## Approval gate label
+
+| Label | Meaning |
+|-------|---------|
+| `claude-ready` | A human has approved this issue for Claude to execute |
+
+This is a temporary gate. When the system is trusted after initial testing, it will be
+removed from `claude.yml` so that the unblocker triggers Claude automatically.
+
+---
+
+## Parent/child structure
+
+- **Parent (epic):** `type:epic` + union of all children's `owner:*` labels
+- **Children (tasks):** one `task:*` + one `owner:*` each
+- Link children as sub-issues (Relationships sidebar → Sub-issues)
+- Set blocking relationships where one task truly cannot start until another finishes
+
+See `docs/ai-workflows.md` for the full planning and routing model.

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -1,6 +1,7 @@
 # Project management conventions
 
-This repo records how we manage work in GitHub Issues and Projects. The rules below are the source of truth for epics, tasks, labels, blocking, and views.
+This repo manages work in GitHub Issues and a GitHub Project board. The rules below
+are the source of truth for how work is created, shaped, routed, and completed.
 
 ---
 
@@ -8,40 +9,71 @@ This repo records how we manage work in GitHub Issues and Projects. The rules be
 
 | Doc | Purpose |
 |-----|--------|
-| **[issue-labels.md](issue-labels.md)** | Executor labels (simple-ai, agentic-ai, human-dev, needs-site-owner), parent/child structure, epic vs task titles, linking and blocking. |
-| **[github-project-views.md](github-project-views.md)** | GitHub Project setup, three views (Epics, Unblocked tasks, Unblocked blocking others), filters, Status field usage, optional API commands. |
-| **[epic-briefs.md](epic-briefs.md)** | Human-readable epic briefs (goal, context, success criteria, scope). Used as parent issue bodies and as input for agents that split epics into tasks. |
+| **[issue-labels.md](issue-labels.md)** | Label taxonomy: source, task-kind, owner, automation state |
+| **[ai-workflows.md](ai-workflows.md)** | Lanes, planner policy, routing rules, unblocker behavior, automation inventory |
+| **[github-project-board.md](github-project-board.md)** | Board setup, Status field, views, branch model, PR targets |
 
 ---
 
 ## Conventions at a glance
 
-- **Parents** = Epics. Title: **Epic: &lt;name&gt;** (e.g. Epic: Single CMS path). Label: **epic**. Labels = epic + union of children’s executor labels.
-- **Children** = Tasks. Title = **task name only** (no "Epic N:"). Exactly **one** executor label per child (simple-ai, agentic-ai, human-dev, or needs-site-owner).
-- **Linking:** Sub-Issues API so Relationships show parent; parent body has task list `- [ ] #N`; each child body has `**Parent:** #M`.
-- **Blocking:** Use issue dependencies (Relationships → Blocked by / Blocking). API: `POST .../issues/{n}/dependencies/blocked_by` with `{"issue_id": blocker_id}`.
-- **Project views:** Epics (`label:epic is:open`), Unblocked tasks (`-label:epic -is:blocked`), Unblocked blocking others (`-label:epic -is:blocked is:blocking`). Status: Backlog → In progress → Done.
-
-When in doubt, open the doc above that matches what you’re doing (labels/structure, project/views, or epic content).
+- **Epics** (`type:epic`): parent deliverables. Title: describe the outcome.
+- **Tasks**: child issues, each with exactly one `task:*` and one `owner:*` label.
+- **Linking**: use GitHub sub-issues (Relationships sidebar) to attach tasks to their epic.
+- **Blocking**: use GitHub issue dependencies (Relationships → Blocked by / Blocking).
+- **Status**: Inbox → Planned → Blocked/Ready → In Progress → In Review → Done
 
 ---
 
-## Automated issue-to-PR workflow (Vercel Comments + Claude)
+## How a new issue flows
 
-The repo has a GitHub Action (`claude-agent.yml`) that lets Claude implement issues automatically. The label system drives it:
+1. Issue created (from Vercel, GitHub, or a human) — lands in **Inbox** on the board
+2. Maintainer adds `automation:plan` — planner workflow runs
+3. Planner shapes the issue and adds `automation:planned` — board moves to **Planned**
+4. If the issue has dependencies, it becomes **Blocked**; otherwise it's **Ready**
+5. When the last blocker closes, `unblocker.yml` releases it to **Ready**
+6. AI or human picks it up — **In Progress** → PR opened → **In Review** → merged → **Done**
 
-1. **Site owner leaves a comment** on a Vercel Preview deployment (the per-deployment hash URL shared by the developer — the comment toolbar is not available on the public alias `profesional-site.vercel.app`) using the Vercel comment toolbar.
-2. **Convert to GitHub Issue** — click the button in the Vercel comment thread to create a GitHub issue with the comment text and a screenshot.
-3. **Triage the issue** — add an executor label and optionally add `from-vercel`:
-   - `simple-ai` — straightforward change (copy, layout tweak, small component fix)
-   - `agentic-ai` — multi-step work (new section, refactor, content model change)
-   - `human-dev` — needs a human (secrets, infrastructure, architectural decisions)
-4. **Approve for automation** — when ready, add `claude-ready`. This triggers the GitHub Action:
-   - `simple-ai + claude-ready` → Claude runs with a simple config (fast model, low max-turns)
-   - `agentic-ai + claude-ready` → Claude runs with a full agentic config (high max-turns)
-5. **Claude opens a PR** targeting `dev` → CI runs → Vercel creates a new preview.
-6. **Review the preview** → merge or leave follow-up comments → repeat.
+See `docs/ai-workflows.md` for detailed planner policy and routing rules.
 
-**`@claude` shortcut:** Comment `@claude <instruction>` on any issue to trigger Claude immediately (uses the simple config, no label required).
+---
 
-**Required secret:** `ANTHROPIC_API_KEY` must be set in GitHub repo Settings → Secrets and variables → Actions for the action to work.
+## Automated issue-to-PR workflow
+
+```
+Issue created → automation:plan label added → planner runs
+→ automation:planned → (blockers clear) → Ready
+→ claude-ready added (or @claude comment) → Claude opens PR
+→ PR merges into epic/* → close-task-on-merge closes issue
+→ unblocker checks dependents
+```
+
+**Vercel feedback:** Agreni leaves a comment on the Vercel preview → clicks
+"Convert to GitHub Issue" → issue is labeled `source:vercel` → add `automation:plan`
+to trigger the planner.
+
+**`@claude` shortcut:** Comment `@claude <instruction>` on any issue or PR to trigger
+Claude immediately (no label required).
+
+---
+
+## Branch and PR conventions
+
+| Branch | Targets | Example |
+|--------|---------|---------|
+| `task/<N>-<slug>` | `epic/<N>-<slug>` (or `dev`) | `task/42-fix-hero-overflow` |
+| `epic/<N>-<slug>` | `dev` | `epic/31-homepage-refresh` |
+| `dev` | `main` | release PR |
+
+Branch names are enforced by `branch-name-check.yml`.
+Issues are closed automatically by `close-task-on-merge.yml` on merge.
+
+---
+
+## Pages CMS content flow
+
+Agreni edits content directly in Pages CMS. These commits go straight to `dev` —
+no PR, no issue, no CI. Vercel auto-rebuilds the preview on every push to `dev`.
+
+Content changes do **not** flow through the task/epic/PR pipeline. This is intentional.
+See `docs/ai-workflows.md` for details.


### PR DESCRIPTION
## Summary
- docs/ai-workflows.md (new): lanes, label taxonomy, planner policy, CMS bypass, automation inventory
- docs/github-project-board.md (new): Status field, board views, branch model, PR targets
- docs/issue-labels.md (rewrite): prefixed label taxonomy
- docs/project-management.md (update): new label names, workflow references
- CONTRIBUTING.md (update): branch model table, full AI section rewrite, CMS bypass note, updated reference docs table
- .github/copilot-instructions.md (new): simple-AI lane instructions for Copilot coding agent

## Test plan
- [ ] markdownlint passes on all new/updated docs
- [ ] Links within docs resolve correctly

Closes #84
Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)