### PR TITLE
fix(cms): fix blank titles and missing testimonials in Pages CMS list views

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -64,7 +64,7 @@ content:
     format: md
     view:
       primary: title
-      fields: [title, description, image, tags, link, date, featured]
+      fields: [description, image, tags, link, date, featured]
       sort: [date, title]
       default:
         sort: date
@@ -115,7 +115,7 @@ content:
     format: md
     view:
       primary: title
-      fields: [title, description, date, tags, draft]
+      fields: [description, date, tags, draft]
       sort: [date, title]
       default:
         sort: date
@@ -154,9 +154,10 @@ content:
     type: collection
     path: site/src/content/testimonials
     format: json
+    filename: "{fields.author}.json"
     view:
       primary: author
-      fields: [author, role, featured]
+      fields: [role, featured]
     fields:
       - name: author
         label: Name


### PR DESCRIPTION
Closes #101

## What changed

Small config fix in `.pages.yml`:

- **Projects + Writing**: removed `title` from `view.fields` (it was duplicating the `view.primary` field, causing Pages CMS to leave the column blank)
- **Testimonials**: added `filename: "{fields.author}.json"` so Pages CMS knows to scan for `.json` files in the directory (without this, it finds nothing)

## Test plan

- [ ] Open Pages CMS → Work / Projects — titles should now display in the list
- [ ] Open Pages CMS → Writing — titles should now display
- [ ] Open Pages CMS → Testimonials — 3 entries should now appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)