### PR TITLE
fix(cms): use yaml-frontmatter format for markdown collections

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -61,7 +61,7 @@ content:
     label: Work / Projects
     type: collection
     path: site/src/content/projects
-    format: md
+    format: yaml-frontmatter
     view:
       primary: title
       fields: [description, image, tags, link, date, featured]
@@ -112,7 +112,7 @@ content:
     label: Writing
     type: collection
     path: site/src/content/writing
-    format: md
+    format: yaml-frontmatter
     view:
       primary: title
       fields: [description, date, tags, draft]


### PR DESCRIPTION
Closes #103

## What changed

Single change in `.pages.yml`: `format: md` → `format: yaml-frontmatter` for the **projects** and **writing** collections.

## Why

`format: md` tells Pages CMS to scan for `.md` files but treats their content as plain text — it never parses the `---` YAML frontmatter block. That's why all field values (title, description, date, tags, everything) were blank in the list view even though the files and data were correct.

`format: yaml-frontmatter` is the format specifier that enables frontmatter parsing. JSON collections have always worked because `format: json` is self-describing.

## Test plan

- [ ] Open Pages CMS → Work / Projects — titles and other fields should now populate
- [ ] Open Pages CMS → Writing — titles, dates, tags should now populate
- [ ] Testimonials should continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)