### PR TITLE
chore(lint): exclude CMS content files from markdownlint

### DIFF
--- a/site/.markdownlintignore
+++ b/site/.markdownlintignore
@@ -1,0 +1,3 @@
+# CMS-managed content files are committed by Pages CMS, which has no
+# knowledge of our lint rules. Exclude them from markdownlint.
+src/content/


### PR DESCRIPTION
Pages CMS commits markdown files directly to the repo without knowledge of our lint rules. Heading levels, blank lines, and other style conventions inside rich-text body fields are outside our control. Linting them creates noise and will break CI every time Agreni uses the Details field on a project entry.

Adds `site/.markdownlintignore` to exclude `src/content/` from markdownlint checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)