### PR TITLE
feat(#115): editorial component library — SectionIntro, TestimonialBlock, WritingList, FeaturePillars, CollaborationCTA

### DIFF
--- a/site/src/components/CollaborationCTA.astro
+++ b/site/src/components/CollaborationCTA.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+  heading?: string;
+  body?: string;
+  href: string;
+  label?: string;
+}
+
+const {
+  heading = "Let's work together",
+  body = "Have a project in mind? I'd love to hear about it.",
+  href,
+  label = 'Get in touch',
+} = Astro.props;
+---
+
+<div class="text-center">
+  <h2 class="mb-4 font-serif text-4xl font-bold md:text-5xl">{heading}</h2>
+  <p class="mx-auto mb-10 max-w-sm text-lg leading-relaxed text-stone-500">
+    {body}
+  </p>
+  <a
+    href={href}
+    class="inline-block rounded-full bg-stone-900 px-10 py-4 text-sm font-medium text-white transition-colors hover:bg-stone-700"
+  >
+    {label}
+  </a>
+</div>

--- a/site/src/components/FeaturePillars.astro
+++ b/site/src/components/FeaturePillars.astro
@@ -1,0 +1,26 @@
+---
+interface Pillar {
+  heading: string;
+  body: string;
+}
+
+interface Props {
+  pillars: Pillar[];
+}
+
+const { pillars } = Astro.props;
+---
+
+<div class="grid gap-10 md:grid-cols-3">
+  {
+    pillars.map((pillar) => (
+      <div>
+        <div class="mb-5 h-px w-8 bg-[#9A5A2E]" />
+        <h3 class="mb-3 font-serif text-lg font-bold leading-snug">
+          {pillar.heading}
+        </h3>
+        <p class="text-sm leading-relaxed text-stone-500">{pillar.body}</p>
+      </div>
+    ))
+  }
+</div>

--- a/site/src/components/SectionIntro.astro
+++ b/site/src/components/SectionIntro.astro
@@ -1,0 +1,47 @@
+---
+interface Props {
+  eyebrow?: string;
+  heading: string;
+  lead?: string;
+  allHref?: string;
+  allLabel?: string;
+}
+
+const {
+  eyebrow,
+  heading,
+  lead,
+  allHref,
+  allLabel = 'View all →',
+} = Astro.props;
+---
+
+<div class="mb-14">
+  <div class="mb-3 flex items-baseline justify-between gap-6">
+    {
+      eyebrow && (
+        <span class="text-xs font-semibold uppercase tracking-[0.14em] text-[#9A5A2E]">
+          {eyebrow}
+        </span>
+      )
+    }
+    {
+      allHref && (
+        <a
+          href={allHref}
+          class="ml-auto shrink-0 text-sm text-stone-400 transition-colors hover:text-stone-900"
+        >
+          {allLabel}
+        </a>
+      )
+    }
+  </div>
+  <h2 class="font-serif text-3xl font-bold md:text-4xl">{heading}</h2>
+  {
+    lead && (
+      <p class="mt-4 max-w-xl text-base leading-relaxed text-stone-500">
+        {lead}
+      </p>
+    )
+  }
+</div>

--- a/site/src/components/TestimonialBlock.astro
+++ b/site/src/components/TestimonialBlock.astro
@@ -1,0 +1,31 @@
+---
+interface Testimonial {
+  quote: string;
+  author: string;
+  role?: string;
+}
+
+interface Props {
+  testimonials: Testimonial[];
+}
+
+const { testimonials } = Astro.props;
+---
+
+<div class={`grid gap-10 ${testimonials.length > 1 ? 'md:grid-cols-2' : ''}`}>
+  {
+    testimonials.map((t) => (
+      <blockquote class="flex flex-col">
+        <p class="relative mb-6 flex-1 pt-5 font-serif text-xl italic leading-relaxed text-stone-800 before:absolute before:left-0 before:top-0 before:h-px before:w-8 before:bg-[#9A5A2E] before:content-['']">
+          {t.quote}
+        </p>
+        <footer>
+          <span class="block text-sm font-semibold text-stone-900">
+            {t.author}
+          </span>
+          {t.role && <span class="block text-xs text-stone-400">{t.role}</span>}
+        </footer>
+      </blockquote>
+    ))
+  }
+</div>

--- a/site/src/components/WritingList.astro
+++ b/site/src/components/WritingList.astro
@@ -1,0 +1,43 @@
+---
+interface Post {
+  id: string;
+  title: string;
+  date: Date;
+  description?: string;
+  href: string;
+}
+
+interface Props {
+  posts: Post[];
+}
+
+const { posts } = Astro.props;
+---
+
+<ul class="divide-y divide-stone-100">
+  {
+    posts.map((post) => (
+      <li class="py-8 first:pt-0 last:pb-0">
+        <time
+          class="mb-1.5 block text-xs text-stone-400"
+          datetime={post.date.toISOString()}
+        >
+          {post.date.toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
+          })}
+        </time>
+        <h3 class="mb-1.5 font-serif text-xl font-bold leading-snug">
+          <a href={post.href} class="transition-colors hover:text-[#9A5A2E]">
+            {post.title}
+          </a>
+        </h3>
+        {post.description && (
+          <p class="text-sm leading-relaxed text-stone-500">
+            {post.description}
+          </p>
+        )}
+      </li>
+    ))
+  }
+</ul>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,6 +1,11 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import Reveal from '../components/Reveal.astro';
+import SectionIntro from '../components/SectionIntro.astro';
+import TestimonialBlock from '../components/TestimonialBlock.astro';
+import WritingList from '../components/WritingList.astro';
+import FeaturePillars from '../components/FeaturePillars.astro';
+import CollaborationCTA from '../components/CollaborationCTA.astro';
 import { getCollection } from 'astro:content';
 import settings from '../content/settings/main.json';
 
@@ -24,6 +29,21 @@ const recentPosts = (await getCollection('writing', ({ data }) => !data.draft))
 const featuredTestimonials = (await getCollection('testimonials'))
   .filter((t) => t.data.featured)
   .slice(0, 2);
+
+const pillars = [
+  {
+    heading: 'Equitable Learning Environments',
+    body: 'Designing classrooms and programs where all students develop as thinkers and feel they belong.',
+  },
+  {
+    heading: 'Curriculum & Pedagogy',
+    body: 'Building curriculum that is rigorous, relevant, and grounded in the realities of classroom life.',
+  },
+  {
+    heading: 'Teacher Learning & Public Scholarship',
+    body: 'Supporting educators through professional development, coaching, and collaborative inquiry — and writing about what this work demands.',
+  },
+];
 ---
 
 <Layout
@@ -46,6 +66,7 @@ const featuredTestimonials = (await getCollection('testimonials'))
       </Fragment>
     )
   }
+
   <!-- Hero -->
   <section
     class="mx-auto flex min-h-screen max-w-5xl flex-col justify-center px-6 pb-16 pt-24"
@@ -87,22 +108,25 @@ const featuredTestimonials = (await getCollection('testimonials'))
     </div>
   </section>
 
+  <!-- Thematic pillars -->
+  <Reveal as="section" class="bg-[#FCFBF8] px-6 py-24">
+    <div class="mx-auto max-w-5xl">
+      <SectionIntro eyebrow="What I do" heading="Areas of focus" />
+      <FeaturePillars pillars={pillars} />
+    </div>
+  </Reveal>
+
   <!-- Featured Work -->
   {
     featured.length > 0 && (
-      <Reveal as="section" class="bg-[#FCFBF8] px-6 py-32" delay={60}>
+      <Reveal as="section" class="px-6 py-24" delay={60}>
         <div class="mx-auto max-w-5xl">
-          <div class="mb-16 flex items-baseline justify-between">
-            <h2 class="font-serif text-3xl font-bold md:text-4xl">
-              Featured Work
-            </h2>
-            <a
-              href={`${base}/work`}
-              class="text-sm text-stone-400 transition-colors hover:text-stone-900"
-            >
-              View all →
-            </a>
-          </div>
+          <SectionIntro
+            eyebrow="Work"
+            heading="Featured Work"
+            allHref={`${base}/work`}
+            allLabel="View all →"
+          />
           <div class="grid gap-10 md:grid-cols-3">
             {featured.map((project) => {
               const p = project.data;
@@ -119,15 +143,15 @@ const featuredTestimonials = (await getCollection('testimonials'))
                         />
                       </div>
                     ) : (
-                      <div class="mb-5 flex aspect-[4/3] items-center justify-center rounded-2xl bg-amber-50">
-                        <span class="font-serif text-5xl italic text-amber-200">
+                      <div class="mb-5 flex aspect-[4/3] items-center justify-center rounded-2xl bg-[#EFE6DA]">
+                        <span class="font-serif text-5xl italic text-[#B87C5A]">
                           {p.title[0]}
                         </span>
                       </div>
                     )}
                     <div class="mb-2 flex flex-wrap gap-3">
                       {p.tags?.map((tag: string) => (
-                        <span class="text-xs font-medium uppercase tracking-widest text-amber-800">
+                        <span class="text-xs font-semibold uppercase tracking-widest text-[#9A5A2E]">
                           {tag}
                         </span>
                       ))}
@@ -149,49 +173,23 @@ const featuredTestimonials = (await getCollection('testimonials'))
   <!-- Recent Writing -->
   {
     recentPosts.length > 0 && (
-      <Reveal as="section" class="mx-auto max-w-3xl px-6 py-32" delay={120}>
-        <div class="mb-12 flex items-baseline justify-between">
-          <h2 class="font-serif text-3xl font-bold md:text-4xl">
-            Recent Writing
-          </h2>
-          <a
-            href={`${base}/writing`}
-            class="text-sm text-stone-400 transition-colors hover:text-stone-900"
-          >
-            All posts →
-          </a>
-        </div>
-        <div class="divide-y divide-stone-100">
-          {recentPosts.map((post) => {
-            const p = post.data;
-            const postUrl = `${base}/writing/${post.id}`;
-            return (
-              <article class="py-8 first:pt-0">
-                <time
-                  class="mb-2 block text-xs text-stone-400"
-                  datetime={p.date.toISOString()}
-                >
-                  {p.date.toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                  })}
-                </time>
-                <h3 class="mb-2 font-serif text-xl font-bold leading-snug">
-                  <a
-                    href={postUrl}
-                    class="transition-colors hover:text-amber-800"
-                  >
-                    {p.title}
-                  </a>
-                </h3>
-                {p.description && (
-                  <p class="text-sm leading-relaxed text-stone-500">
-                    {p.description}
-                  </p>
-                )}
-              </article>
-            );
-          })}
+      <Reveal as="section" class="bg-[#FCFBF8] px-6 py-24" delay={60}>
+        <div class="mx-auto max-w-3xl">
+          <SectionIntro
+            eyebrow="Writing"
+            heading="Recent Writing"
+            allHref={`${base}/writing`}
+            allLabel="All posts →"
+          />
+          <WritingList
+            posts={recentPosts.map((post) => ({
+              id: post.id,
+              title: post.data.title,
+              date: post.data.date,
+              description: post.data.description,
+              href: `${base}/writing/${post.id}`,
+            }))}
+          />
         </div>
       </Reveal>
     )
@@ -200,46 +198,28 @@ const featuredTestimonials = (await getCollection('testimonials'))
   <!-- Testimonials -->
   {
     featuredTestimonials.length > 0 && (
-      <Reveal as="section" class="bg-[#EFE6DA] px-6 py-32" delay={60}>
+      <Reveal as="section" class="bg-[#EFE6DA] px-6 py-24" delay={60}>
         <div class="mx-auto max-w-3xl">
-          <div class="grid gap-10 md:grid-cols-2">
-            {featuredTestimonials.map((t) => {
-              const d = t.data;
-              return (
-                <blockquote class="flex flex-col">
-                  <p class="mb-6 flex-1 font-serif text-xl italic leading-relaxed text-stone-700">
-                    &ldquo;{d.quote}&rdquo;
-                  </p>
-                  <footer>
-                    <span class="block text-sm font-semibold text-stone-900">
-                      {d.author}
-                    </span>
-                    {d.role && (
-                      <span class="block text-xs text-stone-400">{d.role}</span>
-                    )}
-                  </footer>
-                </blockquote>
-              );
-            })}
-          </div>
+          <SectionIntro eyebrow="What people say" heading="Testimonials" />
+          <TestimonialBlock
+            testimonials={featuredTestimonials.map((t) => ({
+              quote: t.data.quote,
+              author: t.data.author,
+              role: t.data.role,
+            }))}
+          />
         </div>
       </Reveal>
     )
   }
 
   <!-- CTA -->
-  <section class="mx-auto max-w-5xl px-6 py-32 text-center">
-    <h2 class="mb-5 font-serif text-4xl font-bold md:text-5xl">
-      Let's work together
-    </h2>
-    <p class="mx-auto mb-10 max-w-sm text-lg leading-relaxed text-stone-500">
-      Have a project in mind? I'd love to hear about it.
-    </p>
-    <a
-      href={`${base}/contact`}
-      class="inline-block rounded-full bg-stone-900 px-10 py-4 text-sm font-medium text-white transition-colors hover:bg-stone-700"
-    >
-      Get in touch
-    </a>
-  </section>
+  <Reveal as="section" class="px-6 py-32">
+    <div class="mx-auto max-w-5xl">
+      <CollaborationCTA
+        href={`${base}/contact`}
+        body="I'm always interested in thoughtful collaborations in education, curriculum, and public scholarship."
+      />
+    </div>
+  </Reveal>
 </Layout>


### PR DESCRIPTION
## Summary

Phase B of epic #112 — adds the editorial building blocks that carry the brand, and wires them into the homepage.

### New components

| Component | Purpose |
|-----------|---------|
| `SectionIntro` | Eyebrow label + serif heading + optional lead + optional "view all" link. Opens every major section. |
| `TestimonialBlock` | Editorial serif italic quotes with a copper accent rule. Attribution below in small sans. No stars, no photos. |
| `WritingList` | Date / serif bold title / description list. Generous spacing, warm hover accent. |
| `FeaturePillars` | 3-col text-only thematic cards with a copper rule. No icons. |
| `CollaborationCTA` | Centered serif heading + body + single primary button. |

### Homepage changes

- Added **Thematic Pillars** section (Equitable Learning Environments / Curriculum & Pedagogy / Teacher Learning) between hero and featured work
- `SectionIntro` replaces ad-hoc heading+link patterns in all three sections
- `WritingList` replaces inline article markup — cleaner and reusable on the writing page
- `TestimonialBlock` replaces inline blockquote markup — editorial style, copper rule divider
- `CollaborationCTA` replaces inline footer CTA with editorial copy
- Work card placeholder now uses brand palette (`#EFE6DA` / `#B87C5A`) instead of Tailwind amber defaults
- CTA copy updated: "I'm always interested in thoughtful collaborations in education, curriculum, and public scholarship."

## Test plan

- [ ] Homepage loads without errors
- [ ] Pillars section visible between hero and Featured Work
- [ ] SectionIntro eyebrow labels render in copper above each heading
- [ ] Testimonials show copper rule above each quote
- [ ] WritingList hover turns titles copper
- [ ] CollaborationCTA links to `/contact`
- [ ] Mobile: pillars stack to 1 column, testimonials stack to 1 column

🤖 Generated with [Claude Code](https://claude.com/claude-code)