### PR TITLE
feat(#116): swap Playfair Display for Cormorant Garamond

### DIFF
--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -46,7 +46,7 @@ const imageUrl = ogImage
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&family=Inter:wght@300;400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,700;1,400;1,700&family=Inter:wght@300;400;500;600&display=swap"
       rel="stylesheet"
     />
     <title>{title}</title>

--- a/site/tailwind.config.mjs
+++ b/site/tailwind.config.mjs
@@ -5,7 +5,7 @@ export default {
     extend: {
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-        serif: ['"Playfair Display"', 'Georgia', 'serif'],
+        serif: ['"Cormorant Garamond"', 'Georgia', 'serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary

Swaps the serif font from Playfair Display to Cormorant Garamond across the entire site.

Cormorant Garamond is more literary and classical — a better fit for the Warm Editorial Academic brand than Playfair's heavier editorial style. The change is two lines: the Google Fonts URL and the Tailwind serif stack.

**Weights loaded:** 400 / 500 / 700 in roman and italic.

## Test plan

- [ ] All serif headings on the homepage render in Cormorant Garamond
- [ ] Hero name italic renders correctly
- [ ] Testimonial quotes (serif italic) render correctly
- [ ] SectionIntro headings render correctly
- [ ] No flash of fallback font (Georgia) on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)