### PR TITLE
fix: reveal content visible without JS (progressive enhancement)

### DIFF
--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -26,6 +26,10 @@ const imageUrl = ogImage
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Mark JS available before first paint so reveal animation only hides content when JS runs -->
+    <script is:inline>
+      document.documentElement.classList.add('js');
+    </script>
     <meta name="description" content={description} />
     <!-- Open Graph -->
     <meta property="og:title" content={title} />

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -30,8 +30,10 @@
     animation-delay: -10s;
   }
 
-  /* Reveal — quiet editorial entrance */
-  .reveal {
+  /* Reveal — quiet editorial entrance.
+     Only hidden when JS is available (html.js set by inline script in <head>).
+     Without JS, content is visible immediately — no functional regression. */
+  html.js .reveal {
     opacity: 0;
     transform: translateY(11px);
     transition:
@@ -40,7 +42,7 @@
     transition-delay: var(--reveal-delay, 0ms);
   }
 
-  .reveal.is-visible {
+  html.js .reveal.is-visible {
     opacity: 1;
     transform: translateY(0);
   }
@@ -62,7 +64,7 @@
     animation: none;
   }
 
-  .reveal {
+  html.js .reveal {
     opacity: 1;
     transform: none;
     transition: none;


### PR DESCRIPTION
## Summary

Addresses the Codex review comment on #120.

**Problem:** `.reveal` starts at `opacity: 0` unconditionally. If JS is disabled, blocked by CSP, or `IntersectionObserver` is unsupported, all major homepage sections (work, writing, testimonials, CTA) stay permanently hidden — a functional regression for users and crawlers.

**Fix:** Gate the hidden state on `html.js`, which is added by a one-liner inline script at the top of `<head>` before first paint. Without JS, `.reveal` elements are fully visible. With JS, they start hidden and animate in as normal.

**Pattern:** Standard progressive enhancement — the same approach used by `no-js` / `js` class techniques across the industry.

## Changes

- `global.css`: `.reveal` → `html.js .reveal` (and matching `is-visible` and `prefers-reduced-motion` selectors)
- `Layout.astro`: `<script is:inline>document.documentElement.classList.add('js');</script>` as first element in `<head>`

## Test plan

- [ ] With JS enabled: sections fade in on scroll as before
- [ ] With JS disabled (devtools → disable JS): all sections visible immediately, no hidden content
- [ ] `prefers-reduced-motion`: sections appear instantly, no animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)