### PR TITLE
Update Agreni site design for warm editorial direction

### DIFF
--- a/site/src/components/FeaturePillars.astro
+++ b/site/src/components/FeaturePillars.astro
@@ -15,11 +15,11 @@ const { pillars } = Astro.props;
   {
     pillars.map((pillar) => (
       <div>
-        <div class="mb-5 h-px w-8 bg-[#9A5A2E]" />
+        <div class="mb-5 h-px w-8 bg-[var(--copper)]" />
         <h3 class="mb-3 font-serif text-lg font-bold leading-snug">
           {pillar.heading}
         </h3>
-        <p class="text-sm leading-relaxed text-stone-500">{pillar.body}</p>
+        <p class="text-sm leading-relaxed text-[var(--stone-soft)]">{pillar.body}</p>
       </div>
     ))
   }

--- a/site/src/components/FeaturePillars.astro
+++ b/site/src/components/FeaturePillars.astro
@@ -19,7 +19,9 @@ const { pillars } = Astro.props;
         <h3 class="mb-3 font-serif text-lg font-bold leading-snug">
           {pillar.heading}
         </h3>
-        <p class="text-sm leading-relaxed text-[var(--stone-soft)]">{pillar.body}</p>
+        <p class="text-sm leading-relaxed text-[var(--stone-soft)]">
+          {pillar.body}
+        </p>
       </div>
     ))
   }

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -11,7 +11,7 @@ const { pathname } = Astro.url;
 ---
 
 <header
-  class="fixed inset-x-0 top-0 z-50 border-b bg-[var(--paper)] border-[var(--warm-line)]"
+  class="fixed inset-x-0 top-0 z-50 border-b border-[var(--warm-line)] bg-[var(--paper)]"
 >
   <nav class="mx-auto flex h-16 max-w-5xl items-center justify-between px-6">
     <a
@@ -29,7 +29,7 @@ const { pathname } = Astro.url;
               class={`text-sm font-medium transition-colors ${
                 pathname.startsWith(href)
                   ? 'text-stone-900'
-                  : 'text-stone-400 hover:text-stone-900'
+                  : 'text-[var(--stone-soft)] hover:text-stone-900'
               }`}
             >
               {label}

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -11,7 +11,7 @@ const { pathname } = Astro.url;
 ---
 
 <header
-  class="fixed inset-x-0 top-0 z-50 border-b border-stone-100 bg-stone-50/80 backdrop-blur-md"
+  class="fixed inset-x-0 top-0 z-50 border-b bg-[var(--paper)] border-[var(--warm-line)]"
 >
   <nav class="mx-auto flex h-16 max-w-5xl items-center justify-between px-6">
     <a

--- a/site/src/components/SectionIntro.astro
+++ b/site/src/components/SectionIntro.astro
@@ -20,7 +20,7 @@ const {
   <div class="mb-3 flex items-baseline justify-between gap-6">
     {
       eyebrow && (
-        <span class="text-xs font-semibold uppercase tracking-[0.14em] text-[#9A5A2E]">
+        <span class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--copper)]">
           {eyebrow}
         </span>
       )

--- a/site/src/components/TestimonialBlock.astro
+++ b/site/src/components/TestimonialBlock.astro
@@ -16,7 +16,7 @@ const { testimonials } = Astro.props;
   {
     testimonials.map((t) => (
       <blockquote class="flex flex-col">
-        <p class="relative mb-6 flex-1 pt-5 font-serif text-xl italic leading-relaxed text-stone-800 before:absolute before:left-0 before:top-0 before:h-px before:w-8 before:bg-[#9A5A2E] before:content-['']">
+        <p class="relative mb-6 flex-1 pt-5 font-serif text-xl italic leading-relaxed text-[var(--ink)] before:absolute before:left-0 before:top-0 before:h-px before:w-8 before:bg-[var(--copper)] before:content-['']">
           {t.quote}
         </p>
         <footer>

--- a/site/src/components/WritingList.astro
+++ b/site/src/components/WritingList.astro
@@ -28,7 +28,10 @@ const { posts } = Astro.props;
           })}
         </time>
         <h3 class="mb-1.5 font-serif text-xl font-bold leading-snug">
-          <a href={post.href} class="transition-colors hover:text-[var(--copper)]">
+          <a
+            href={post.href}
+            class="transition-colors hover:text-[var(--copper)]"
+          >
             {post.title}
           </a>
         </h3>

--- a/site/src/components/WritingList.astro
+++ b/site/src/components/WritingList.astro
@@ -28,7 +28,7 @@ const { posts } = Astro.props;
           })}
         </time>
         <h3 class="mb-1.5 font-serif text-xl font-bold leading-snug">
-          <a href={post.href} class="transition-colors hover:text-[#9A5A2E]">
+          <a href={post.href} class="transition-colors hover:text-[var(--copper)]">
             {post.title}
           </a>
         </h3>

--- a/site/src/content/settings/main.json
+++ b/site/src/content/settings/main.json
@@ -1,7 +1,7 @@
 {
   "name": "Agreni",
-  "tagline": "Creative professional who brings ideas to life!",
-  "bio": "I'm a creative professional with a passion for thoughtful design and meaningful work. I collaborate with brands and individuals to create experiences that resonate and endure.\n\nBased in New York City, I'm always open to new projects and conversations.",
+  "tagline": "educator, curriculum designer, and writer interested in how classrooms become places where thinking flourishes.",
+  "bio": "I work at the intersection of equitable learning environments, curriculum development, and teacher learning. My practice centers on making rigorous, humane education more possible in schools.",
   "email": "hello@example.com",
   "bookingUrl": "",
   "photo": "",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -69,37 +69,29 @@ const pillars = [
 
   <!-- Hero -->
   <section
-    class="mx-auto flex min-h-screen max-w-5xl flex-col justify-center px-6 pb-16 pt-24"
+    class="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 pb-16 pt-24"
   >
-    <p
-      class="mb-8 text-xs font-medium uppercase tracking-[0.25em] text-amber-800"
-    >
-      Welcome
-    </p>
-    <h1 class="mb-8 font-serif font-bold leading-[1.05] text-stone-900">
-      <span class="block text-6xl md:text-8xl lg:text-9xl">Hi, I'm</span>
-      <span class="block text-6xl italic text-amber-800 md:text-8xl lg:text-9xl"
-        >{settings.name}</span
-      >
+    <h1 class="mb-6 font-serif text-4xl font-bold leading-tight text-[var(--ink)] md:text-5xl lg:text-6xl">
+      <span class="text-[var(--copper)]">{settings.name}</span> is an educator, curriculum designer, and writer interested in how classrooms become places where thinking flourishes.
     </h1>
     <p
-      class="mb-12 max-w-md text-xl leading-relaxed text-stone-500 md:text-2xl"
+      class="mb-10 max-w-2xl text-lg leading-relaxed text-[var(--stone-soft)] md:text-xl"
     >
-      {settings.tagline}
+      I work at the intersection of equitable learning environments, curriculum development, and teacher learning. My practice centers on making rigorous, humane education more possible in schools.
     </p>
     <div class="flex flex-wrap gap-4">
       <a
         href={`${base}/work`}
-        class="rounded-full bg-stone-900 px-8 py-3.5 text-sm font-medium text-white transition-colors hover:bg-stone-700"
+        class="rounded-full bg-[var(--ink)] px-8 py-3.5 text-sm font-medium text-white transition-colors hover:bg-[var(--stone-soft)]"
       >
-        See my work
+        Explore my work
       </a>
       {
         bookingUrl && (
           <a
             href=""
             onclick={`Calendly.initPopupWidget({url:'${bookingUrl}'});return false;`}
-            class="rounded-full border border-stone-300 px-8 py-3.5 text-sm font-medium transition-colors hover:border-stone-700"
+            class="rounded-full border border-[var(--warm-line)] px-8 py-3.5 text-sm font-medium text-[var(--ink)] transition-colors hover:border-[var(--stone-soft)]"
           >
             Book a conversation
           </a>
@@ -109,7 +101,7 @@ const pillars = [
   </section>
 
   <!-- Thematic pillars -->
-  <Reveal as="section" class="bg-[#FCFBF8] px-6 py-24">
+  <Reveal as="section" class="bg-[var(--paper-light)] border-t border-[var(--warm-line)] px-6 py-24">
     <div class="mx-auto max-w-5xl">
       <SectionIntro eyebrow="What I do" heading="Areas of focus" />
       <FeaturePillars pillars={pillars} />
@@ -143,21 +135,21 @@ const pillars = [
                         />
                       </div>
                     ) : (
-                      <div class="mb-5 flex aspect-[4/3] items-center justify-center rounded-2xl bg-[#EFE6DA]">
-                        <span class="font-serif text-5xl italic text-[#B87C5A]">
+                      <div class="mb-5 flex aspect-[4/3] items-center justify-center rounded-2xl bg-[var(--pale-sand)]">
+                        <span class="font-serif text-5xl italic text-[var(--clay)]">
                           {p.title[0]}
                         </span>
                       </div>
                     )}
                     <div class="mb-2 flex flex-wrap gap-3">
                       {p.tags?.map((tag: string) => (
-                        <span class="text-xs font-semibold uppercase tracking-widest text-[#9A5A2E]">
+                        <span class="text-xs font-semibold uppercase tracking-widest text-[var(--copper)]">
                           {tag}
                         </span>
                       ))}
                     </div>
                     <h3 class="mb-2 font-serif text-xl font-bold">{p.title}</h3>
-                    <p class="text-sm leading-relaxed text-stone-500">
+                    <p class="text-sm leading-relaxed text-[var(--stone-soft)]">
                       {p.description}
                     </p>
                   </article>
@@ -173,7 +165,7 @@ const pillars = [
   <!-- Recent Writing -->
   {
     recentPosts.length > 0 && (
-      <Reveal as="section" class="bg-[#FCFBF8] px-6 py-24" delay={60}>
+      <Reveal as="section" class="bg-[var(--paper-light)] border-t border-[var(--warm-line)] px-6 py-24" delay={60}>
         <div class="mx-auto max-w-3xl">
           <SectionIntro
             eyebrow="Writing"
@@ -198,7 +190,7 @@ const pillars = [
   <!-- Testimonials -->
   {
     featuredTestimonials.length > 0 && (
-      <Reveal as="section" class="bg-[#EFE6DA] px-6 py-24" delay={60}>
+      <Reveal as="section" class="bg-[var(--pale-sand)] border-t border-[var(--warm-line)] px-6 py-24" delay={60}>
         <div class="mx-auto max-w-3xl">
           <SectionIntro eyebrow="What people say" heading="Testimonials" />
           <TestimonialBlock

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -71,13 +71,16 @@ const pillars = [
   <section
     class="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 pb-16 pt-24"
   >
-    <h1 class="mb-6 font-serif text-4xl font-bold leading-tight text-[var(--ink)] md:text-5xl lg:text-6xl">
-      <span class="text-[var(--copper)]">{settings.name}</span> is an educator, curriculum designer, and writer interested in how classrooms become places where thinking flourishes.
+    <h1
+      class="mb-6 font-serif text-4xl font-bold leading-tight text-[var(--ink)] md:text-5xl lg:text-6xl"
+    >
+      <span class="text-[var(--copper)]">{settings.name}</span>
+      {settings.tagline}
     </h1>
     <p
       class="mb-10 max-w-2xl text-lg leading-relaxed text-[var(--stone-soft)] md:text-xl"
     >
-      I work at the intersection of equitable learning environments, curriculum development, and teacher learning. My practice centers on making rigorous, humane education more possible in schools.
+      {settings.bio}
     </p>
     <div class="flex flex-wrap gap-4">
       <a
@@ -89,7 +92,7 @@ const pillars = [
       {
         bookingUrl && (
           <a
-            href=""
+            href={bookingUrl}
             onclick={`Calendly.initPopupWidget({url:'${bookingUrl}'});return false;`}
             class="rounded-full border border-[var(--warm-line)] px-8 py-3.5 text-sm font-medium text-[var(--ink)] transition-colors hover:border-[var(--stone-soft)]"
           >
@@ -101,7 +104,10 @@ const pillars = [
   </section>
 
   <!-- Thematic pillars -->
-  <Reveal as="section" class="bg-[var(--paper-light)] border-t border-[var(--warm-line)] px-6 py-24">
+  <Reveal
+    as="section"
+    class="border-t border-[var(--warm-line)] bg-[var(--paper-light)] px-6 py-24"
+  >
     <div class="mx-auto max-w-5xl">
       <SectionIntro eyebrow="What I do" heading="Areas of focus" />
       <FeaturePillars pillars={pillars} />
@@ -165,7 +171,11 @@ const pillars = [
   <!-- Recent Writing -->
   {
     recentPosts.length > 0 && (
-      <Reveal as="section" class="bg-[var(--paper-light)] border-t border-[var(--warm-line)] px-6 py-24" delay={60}>
+      <Reveal
+        as="section"
+        class="border-t border-[var(--warm-line)] bg-[var(--paper-light)] px-6 py-24"
+        delay={60}
+      >
         <div class="mx-auto max-w-3xl">
           <SectionIntro
             eyebrow="Writing"
@@ -190,7 +200,11 @@ const pillars = [
   <!-- Testimonials -->
   {
     featuredTestimonials.length > 0 && (
-      <Reveal as="section" class="bg-[var(--pale-sand)] border-t border-[var(--warm-line)] px-6 py-24" delay={60}>
+      <Reveal
+        as="section"
+        class="border-t border-[var(--warm-line)] bg-[var(--pale-sand)] px-6 py-24"
+        delay={60}
+      >
         <div class="mx-auto max-w-3xl">
           <SectionIntro eyebrow="What people say" heading="Testimonials" />
           <TestimonialBlock

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -3,6 +3,19 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    /* Brand palette — warm editorial academic */
+    --paper: #F7F4EF;
+    --paper-light: #FCFBF8;
+    --ink: #1E1A17;
+    --stone-soft: #6B625B;
+    --copper: #9A5A2E;
+    --clay: #B87C5A;
+    --warm-line: #E6DED3;
+    --pale-sand: #EFE6DA;
+    --olive: #5C6650;
+  }
+
   html {
     scroll-behavior: smooth;
   }
@@ -13,7 +26,7 @@
   .ambient-blob {
     @apply absolute rounded-full;
 
-    opacity: 0.18;
+    opacity: 0.16;
     filter: blur(72px) saturate(1.05);
     animation: float 20s ease-in-out infinite;
   }
@@ -35,10 +48,10 @@
      Without JS, content is visible immediately — no functional regression. */
   html.js .reveal {
     opacity: 0;
-    transform: translateY(11px);
+    transform: translateY(9px);
     transition:
-      opacity 550ms cubic-bezier(0.25, 0.1, 0.25, 1),
-      transform 550ms cubic-bezier(0.25, 0.1, 0.25, 1);
+      opacity 480ms cubic-bezier(0.25, 0.1, 0.25, 1),
+      transform 480ms cubic-bezier(0.25, 0.1, 0.25, 1);
     transition-delay: var(--reveal-delay, 0ms);
   }
 

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -5,15 +5,15 @@
 @layer base {
   :root {
     /* Brand palette — warm editorial academic */
-    --paper: #F7F4EF;
-    --paper-light: #FCFBF8;
-    --ink: #1E1A17;
-    --stone-soft: #6B625B;
-    --copper: #9A5A2E;
-    --clay: #B87C5A;
-    --warm-line: #E6DED3;
-    --pale-sand: #EFE6DA;
-    --olive: #5C6650;
+    --paper: #f7f4ef;
+    --paper-light: #fcfbf8;
+    --ink: #1e1a17;
+    --stone-soft: #6b625b;
+    --copper: #9a5a2e;
+    --clay: #b87c5a;
+    --warm-line: #e6ded3;
+    --pale-sand: #efe6da;
+    --olive: #5c6650;
   }
 
   html {


### PR DESCRIPTION
## Summary

Refreshes the Astro site's visual design toward a warm editorial palette by introducing global CSS custom properties and updating key page/component styling to consume those tokens. Follow-up fixes address accessibility, CMS content consistency, and link behaviour based on code review feedback.

## Changes

- Implemented new CSS custom properties to establish a warm editorial color palette (`--paper`, `--ink`, `--copper`, `--stone-soft`, `--warm-line`).
- Updated navigation, hero section, and core UI components to align with the refreshed visual identity.
- Fixed Calendly CTA anchor `href` from `""` to `bookingUrl` so the link behaves correctly as a non-JS fallback.
- Synced hero copy with CMS: updated `settings/main.json` with real tagline and bio, and updated the hero template to use `settings.tagline` / `settings.bio` so on-page content stays in sync with page metadata.
- Fixed low-contrast inactive nav link color (`text-stone-400` → `text-[var(--stone-soft)]`) to meet WCAG AA contrast requirements against the `--paper` background.

[v0 Session](https://v0.app/chat/ghS1zZteMcz)

## Test plan

- [ ] `npm run build` passes
- [ ] Visual check in browser via `npm run dev`

## Branch checklist

- [ ] Target branch is `dev` (feature/fix PRs) — or `main` only if this is a release PR (`dev` → `main`)
- [ ] Branch created from `dev`, not `main`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)