### PR TITLE
fix(deps): add zod to site dependencies

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@astrojs/tailwind": "^6.0.2",
         "astro": "^6.1.1",
-        "tailwindcss": "^3.4.14"
+        "tailwindcss": "^3.4.14",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",

--- a/site/package.json
+++ b/site/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "@astrojs/tailwind": "^6.0.2",
     "astro": "^6.1.1",
-    "tailwindcss": "^3.4.14"
+    "tailwindcss": "^3.4.14",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",


### PR DESCRIPTION
## Summary
- Adds `zod` to `site/package.json` dependencies
- `site/src/content.config.ts` imports `z` directly from `zod` but the package was not declared, causing Astro to fail at startup with `[ERROR] [content] Cannot find module 'zod'`
- This was breaking Vercel preview builds including PR #125

## Root cause
`content.config.ts` defines content collection schemas using `z.object(...)` from `zod`, but `zod` was only installed transiently (via another package) rather than declared explicitly. Vercel's isolated build environment doesn't have it available.

## Test plan
- [ ] Verify Vercel preview build succeeds after this merges
- [ ] Confirm `astro build` runs without the zod module error

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)