### PR TITLE
feat: upgrade /admin to GitHub OAuth

### DIFF
--- a/site/api/auth/callback.ts
+++ b/site/api/auth/callback.ts
@@ -1,0 +1,91 @@
+export const config = { runtime: 'edge' };
+
+async function hmac(data: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(data)
+  );
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  if (!code) {
+    return new Response('Missing OAuth code', { status: 400 });
+  }
+
+  // Exchange code for access token
+  const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      code,
+    }),
+  });
+  const tokenData = (await tokenRes.json()) as {
+    access_token?: string;
+    error?: string;
+  };
+  if (!tokenData.access_token) {
+    return new Response('OAuth token exchange failed', { status: 400 });
+  }
+
+  const { access_token } = tokenData;
+
+  // Get authenticated GitHub user
+  const userRes = await fetch('https://api.github.com/user', {
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'profesional-site-admin',
+    },
+  });
+  const user = (await userRes.json()) as { login: string };
+  const { login } = user;
+
+  // Verify the user is a repo collaborator
+  const collabRes = await fetch(
+    `https://api.github.com/repos/rainonej/profesional_site/collaborators/${login}`,
+    {
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'profesional-site-admin',
+      },
+    }
+  );
+  if (collabRes.status !== 204) {
+    return new Response('Access denied — not a repo collaborator', {
+      status: 403,
+    });
+  }
+
+  // Create signed session token: "{login}.{hmac(login)}"
+  const sig = await hmac(login, process.env.SESSION_SECRET!);
+  const sessionToken = `${login}.${sig}`;
+  const maxAge = 24 * 60 * 60; // 24 hours
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: `${url.origin}/admin`,
+      'Set-Cookie': `session=${sessionToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${maxAge}`,
+    },
+  });
+}

--- a/site/api/auth/callback.ts
+++ b/site/api/auth/callback.ts
@@ -1,5 +1,17 @@
 export const config = { runtime: 'edge' };
 
+function parseCookies(header: string | null): Record<string, string> {
+  if (!header) return {};
+  return Object.fromEntries(
+    header.split(';').map((c) => {
+      const eq = c.indexOf('=');
+      return eq === -1
+        ? [c.trim(), '']
+        : [c.slice(0, eq).trim(), c.slice(eq + 1).trim()];
+    })
+  );
+}
+
 async function hmac(data: string, secret: string): Promise<string> {
   const key = await crypto.subtle.importKey(
     'raw',
@@ -21,6 +33,15 @@ async function hmac(data: string, secret: string): Promise<string> {
 export default async function handler(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const code = url.searchParams.get('code');
+  const stateParam = url.searchParams.get('state');
+
+  // Verify CSRF state
+  const cookies = parseCookies(request.headers.get('cookie'));
+  const storedState = cookies['oauth_state'];
+  if (!stateParam || !storedState || stateParam !== storedState) {
+    return new Response('Invalid state parameter', { status: 400 });
+  }
+
   if (!code) {
     return new Response('Missing OAuth code', { status: 400 });
   }
@@ -76,16 +97,24 @@ export default async function handler(request: Request): Promise<Response> {
     });
   }
 
-  // Create signed session token: "{login}.{hmac(login)}"
-  const sig = await hmac(login, process.env.SESSION_SECRET!);
-  const sessionToken = `${login}.${sig}`;
-  const maxAge = 24 * 60 * 60; // 24 hours
+  // Create signed session token: "{login}.{issuedAt}.{hmac(login.issuedAt)}"
+  // The issuedAt timestamp is included in the signed payload so expiry is
+  // enforced server-side in /api/auth/session, not just via cookie Max-Age.
+  const issuedAt = Date.now().toString();
+  const payload = `${login}.${issuedAt}`;
+  const sig = await hmac(payload, process.env.SESSION_SECRET!);
+  const sessionToken = `${payload}.${sig}`;
+  const maxAge = 24 * 60 * 60; // 24 hours in seconds
 
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: `${url.origin}/admin`,
-      'Set-Cookie': `session=${sessionToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${maxAge}`,
-    },
-  });
+  const headers = new Headers({ Location: `${url.origin}/admin` });
+  headers.append(
+    'Set-Cookie',
+    `session=${sessionToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${maxAge}`
+  );
+  // Clear the one-time CSRF state cookie
+  headers.append(
+    'Set-Cookie',
+    'oauth_state=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0'
+  );
+  return new Response(null, { status: 302, headers });
 }

--- a/site/api/auth/github.ts
+++ b/site/api/auth/github.ts
@@ -1,0 +1,13 @@
+export const config = { runtime: 'edge' };
+
+export default function handler(): Response {
+  const clientId = process.env.GITHUB_CLIENT_ID!;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    scope: 'read:user public_repo',
+  });
+  return Response.redirect(
+    `https://github.com/login/oauth/authorize?${params}`,
+    302
+  );
+}

--- a/site/api/auth/github.ts
+++ b/site/api/auth/github.ts
@@ -2,12 +2,16 @@ export const config = { runtime: 'edge' };
 
 export default function handler(): Response {
   const clientId = process.env.GITHUB_CLIENT_ID!;
+  const state = crypto.randomUUID();
   const params = new URLSearchParams({
     client_id: clientId,
     scope: 'read:user public_repo',
+    state,
   });
-  return Response.redirect(
-    `https://github.com/login/oauth/authorize?${params}`,
-    302
-  );
+  const headers = new Headers({
+    Location: `https://github.com/login/oauth/authorize?${params}`,
+    // Store state in a short-lived httpOnly cookie for CSRF verification in callback
+    'Set-Cookie': `oauth_state=${state}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=600`,
+  });
+  return new Response(null, { status: 302, headers });
 }

--- a/site/api/auth/logout.ts
+++ b/site/api/auth/logout.ts
@@ -1,0 +1,13 @@
+export const config = { runtime: 'edge' };
+
+export default function handler(request: Request): Response {
+  const { origin } = new URL(request.url);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: `${origin}/`,
+      'Set-Cookie':
+        'session=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0',
+    },
+  });
+}

--- a/site/api/auth/session.ts
+++ b/site/api/auth/session.ts
@@ -1,0 +1,57 @@
+export const config = { runtime: 'edge' };
+
+function parseCookies(header: string | null): Record<string, string> {
+  if (!header) return {};
+  return Object.fromEntries(
+    header.split(';').map((c) => {
+      const eq = c.indexOf('=');
+      return eq === -1
+        ? [c.trim(), '']
+        : [c.slice(0, eq).trim(), c.slice(eq + 1).trim()];
+    })
+  );
+}
+
+async function verifyToken(
+  token: string,
+  secret: string
+): Promise<string | null> {
+  const dot = token.lastIndexOf('.');
+  if (dot === -1) return null;
+  const username = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const expected = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(username)
+  );
+  const expectedHex = Array.from(new Uint8Array(expected))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  return sig === expectedHex ? username : null;
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const cookies = parseCookies(request.headers.get('cookie'));
+  const token = cookies['session'];
+
+  if (!token) {
+    return Response.json({ authenticated: false });
+  }
+
+  const username = await verifyToken(token, process.env.SESSION_SECRET!);
+  if (!username) {
+    return Response.json({ authenticated: false });
+  }
+
+  return Response.json({ authenticated: true, username });
+}

--- a/site/api/auth/session.ts
+++ b/site/api/auth/session.ts
@@ -1,5 +1,7 @@
 export const config = { runtime: 'edge' };
 
+const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
 function parseCookies(header: string | null): Record<string, string> {
   if (!header) return {};
   return Object.fromEntries(
@@ -16,11 +18,13 @@ async function verifyToken(
   token: string,
   secret: string
 ): Promise<string | null> {
-  const dot = token.lastIndexOf('.');
-  if (dot === -1) return null;
-  const username = token.slice(0, dot);
-  const sig = token.slice(dot + 1);
+  // Token format: "{login}.{issuedAt}.{hmac(login.issuedAt)}"
+  const lastDot = token.lastIndexOf('.');
+  if (lastDot === -1) return null;
+  const payload = token.slice(0, lastDot); // "login.issuedAt"
+  const sig = token.slice(lastDot + 1);
 
+  // Verify HMAC signature
   const key = await crypto.subtle.importKey(
     'raw',
     new TextEncoder().encode(secret),
@@ -31,13 +35,25 @@ async function verifyToken(
   const expected = await crypto.subtle.sign(
     'HMAC',
     key,
-    new TextEncoder().encode(username)
+    new TextEncoder().encode(payload)
   );
   const expectedHex = Array.from(new Uint8Array(expected))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
+  if (sig !== expectedHex) return null;
 
-  return sig === expectedHex ? username : null;
+  // Extract login and issuedAt from payload
+  const firstDot = payload.indexOf('.');
+  if (firstDot === -1) return null;
+  const login = payload.slice(0, firstDot);
+  const issuedAt = parseInt(payload.slice(firstDot + 1), 10);
+
+  // Reject expired tokens (server-side check independent of cookie Max-Age)
+  if (Number.isNaN(issuedAt) || Date.now() - issuedAt > SESSION_MAX_AGE_MS) {
+    return null;
+  }
+
+  return login;
 }
 
 export default async function handler(request: Request): Promise<Response> {

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
         "@eslint/js": "^9.15.0",
+        "@types/node": "^25.5.0",
         "eslint": "^9.15.0",
         "eslint-plugin-astro": "^1.2.0",
         "husky": "^9.1.7",
@@ -2270,6 +2271,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/unist": {
@@ -8446,6 +8457,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/site/package.json
+++ b/site/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
     "@eslint/js": "^9.15.0",
+    "@types/node": "^25.5.0",
     "eslint": "^9.15.0",
     "eslint-plugin-astro": "^1.2.0",
     "husky": "^9.1.7",

--- a/site/src/pages/admin.astro
+++ b/site/src/pages/admin.astro
@@ -1,0 +1,279 @@
+---
+import Layout from '../layouts/Layout.astro';
+
+const sitemap = `flowchart TD
+  Home["/ — Home"]
+  About["/about — About"]
+  Work["/work — Work"]
+  Writing["/writing — Writing"]
+  Contact["/contact — Contact"]
+  WorkSlug["/work/slug — Project Detail"]
+  WritingSlug["/writing/slug — Essay Detail"]
+
+  Home --> About
+  Home --> Work
+  Home --> Writing
+  Home --> Contact
+  Work --> WorkSlug
+  Writing --> WritingSlug`;
+---
+
+<Layout title="Admin — Site Overview">
+  <!-- Loading / auth gate -->
+  <div
+    id="gate"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-[var(--paper)]"
+  >
+    <div class="flex flex-col items-center gap-4 text-center">
+      <span class="font-serif text-3xl italic text-[var(--ink)]">Admin</span>
+      <span id="gate-status" class="text-sm text-[var(--stone-soft)]"
+        >Checking session…</span
+      >
+    </div>
+  </div>
+
+  <!-- Admin content (visible after auth) -->
+  <div id="admin-content" class="hidden">
+    <div class="mx-auto max-w-5xl px-6 pb-32 pt-40">
+      <header class="mb-20 border-b border-[var(--warm-line)] pb-10">
+        <p
+          class="mb-2 text-xs font-semibold uppercase tracking-[0.25em] text-[var(--copper)]"
+        >
+          Private
+        </p>
+        <h1 class="font-serif text-5xl font-bold text-[var(--ink)]">
+          Site Overview
+        </h1>
+        <p class="mt-3 text-[var(--stone-soft)]">
+          Live design tokens, typography, and site structure.
+        </p>
+        <button
+          id="logout-btn"
+          class="mt-6 text-xs text-[var(--stone-soft)] underline underline-offset-2 hover:text-[var(--ink)]"
+        >
+          Log out
+        </button>
+      </header>
+
+      <!-- ── Color Palette ───────────────────────────────────────────── -->
+      <section class="mb-20">
+        <h2
+          class="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-[var(--copper)]"
+        >
+          Colors
+        </h2>
+        <p class="mb-8 font-serif text-3xl font-bold text-[var(--ink)]">
+          Design Tokens
+        </p>
+        <div
+          id="color-swatches"
+          class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4"
+        >
+        </div>
+      </section>
+
+      <!-- ── Typography ─────────────────────────────────────────────── -->
+      <section class="mb-20 border-t border-[var(--warm-line)] pt-16">
+        <h2
+          class="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-[var(--copper)]"
+        >
+          Typography
+        </h2>
+        <p class="mb-10 font-serif text-3xl font-bold text-[var(--ink)]">
+          Type Styles
+        </p>
+
+        <div class="space-y-10">
+          <!-- Serif -->
+          <div class="rounded-2xl border border-[var(--warm-line)] p-8">
+            <p class="mb-3 text-xs text-[var(--stone-soft)]">
+              font-serif — Cormorant Garamond
+            </p>
+            <p
+              class="font-serif text-6xl font-bold italic leading-none text-[var(--ink)]"
+            >
+              Aa
+            </p>
+            <p class="mt-4 font-serif text-3xl font-bold text-[var(--ink)]">
+              Page heading — bold serif
+            </p>
+            <p class="mt-2 font-serif text-2xl italic text-[var(--ink)]">
+              Page heading — italic serif
+            </p>
+            <p class="mt-2 font-serif text-xl text-[var(--ink)]">
+              Section heading — regular serif
+            </p>
+          </div>
+
+          <!-- Sans -->
+          <div class="rounded-2xl border border-[var(--warm-line)] p-8">
+            <p class="mb-3 text-xs text-[var(--stone-soft)]">
+              font-sans — Inter
+            </p>
+            <p class="text-6xl font-semibold leading-none text-[var(--ink)]">
+              Aa
+            </p>
+            <p class="mt-4 text-lg font-semibold text-[var(--ink)]">
+              Body text — semibold
+            </p>
+            <p class="mt-2 text-base leading-relaxed text-[var(--stone-soft)]">
+              Body text — regular. This is a sample paragraph showing how
+              reading text looks on the site using Inter at base size with
+              relaxed line-height.
+            </p>
+            <p class="mt-2 text-sm text-[var(--stone-soft)]">
+              Small text — labels, captions, metadata
+            </p>
+            <p
+              class="mt-2 text-xs font-semibold uppercase tracking-[0.25em] text-[var(--copper)]"
+            >
+              Eyebrow label — uppercase tracked
+            </p>
+          </div>
+
+          <!-- Buttons -->
+          <div class="rounded-2xl border border-[var(--warm-line)] p-8">
+            <p class="mb-5 text-xs text-[var(--stone-soft)]">
+              Interactive elements
+            </p>
+            <div class="flex flex-wrap gap-4">
+              <span
+                class="rounded-full bg-[var(--ink)] px-8 py-3 text-sm font-medium text-white"
+              >
+                Primary button
+              </span>
+              <span
+                class="rounded-full border border-[var(--warm-line)] px-8 py-3 text-sm font-medium text-[var(--ink)]"
+              >
+                Secondary button
+              </span>
+              <span
+                class="text-sm font-medium text-[var(--copper)] underline underline-offset-4"
+              >
+                Text link →
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── Site Map ────────────────────────────────────────────────── -->
+      <section class="border-t border-[var(--warm-line)] pt-16">
+        <h2
+          class="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-[var(--copper)]"
+        >
+          Structure
+        </h2>
+        <p class="mb-3 font-serif text-3xl font-bold text-[var(--ink)]">
+          Site Map
+        </p>
+        <p class="mb-8 text-sm text-[var(--stone-soft)]">
+          All pages and how they connect. Leave a Vercel comment on this page to
+          request structural changes (e.g. "add a Hobbies page linked from
+          About").
+        </p>
+        <div
+          id="mermaid-diagram"
+          class="overflow-x-auto rounded-2xl border border-[var(--warm-line)] bg-[var(--paper-light)] p-8"
+        >
+          <pre class="mermaid">{sitemap}</pre>
+        </div>
+      </section>
+    </div>
+  </div>
+</Layout>
+
+<script>
+  // ── Auth ────────────────────────────────────────────────────────────
+  const gate = document.getElementById('gate')!;
+  const gateStatus = document.getElementById('gate-status')!;
+  const content = document.getElementById('admin-content')!;
+  const logoutBtn = document.getElementById('logout-btn')!;
+
+  function unlock() {
+    gate.style.display = 'none';
+    content.classList.remove('hidden');
+    initDesignSystem();
+    initMermaid();
+  }
+
+  async function checkSession() {
+    try {
+      const res = await fetch('/api/auth/session');
+      if (!res.ok) throw new Error('no session endpoint');
+      const data = await res.json();
+      if (data.authenticated) {
+        unlock();
+      } else {
+        gateStatus.textContent = 'Redirecting to GitHub…';
+        window.location.href = '/api/auth/github';
+      }
+    } catch {
+      gateStatus.textContent = 'Admin unavailable in this environment.';
+    }
+  }
+
+  checkSession();
+
+  logoutBtn.addEventListener('click', () => {
+    window.location.href = '/api/auth/logout';
+  });
+
+  // ── Design tokens ────────────────────────────────────────────────────
+  function initDesignSystem() {
+    const style = getComputedStyle(document.documentElement);
+    const tokens = [
+      { name: '--paper', label: 'Paper' },
+      { name: '--paper-light', label: 'Paper Light' },
+      { name: '--ink', label: 'Ink' },
+      { name: '--stone-soft', label: 'Stone Soft' },
+      { name: '--copper', label: 'Copper' },
+      { name: '--clay', label: 'Clay' },
+      { name: '--warm-line', label: 'Warm Line' },
+      { name: '--pale-sand', label: 'Pale Sand' },
+      { name: '--olive', label: 'Olive' },
+    ];
+
+    const container = document.getElementById('color-swatches')!;
+    tokens.forEach(({ name, label }) => {
+      const value = style.getPropertyValue(name).trim();
+      const swatch = document.createElement('div');
+      swatch.className =
+        'rounded-xl overflow-hidden border border-[var(--warm-line)]';
+      swatch.innerHTML = `
+        <div style="background:${value}; height: 80px;"></div>
+        <div class="p-3 bg-[var(--paper-light)]">
+          <p class="text-xs font-semibold text-[var(--ink)]">${label}</p>
+          <p class="text-xs text-[var(--stone-soft)] font-mono mt-0.5">${value}</p>
+          <p class="text-xs text-[var(--stone-soft)] font-mono">${name}</p>
+        </div>
+      `;
+      container.appendChild(swatch);
+    });
+  }
+
+  // ── Mermaid ──────────────────────────────────────────────────────────
+  function initMermaid() {
+    const script = document.createElement('script');
+    script.type = 'module';
+    script.textContent = `
+      import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+      mermaid.initialize({
+        startOnLoad: true,
+        theme: 'base',
+        themeVariables: {
+          primaryColor: '#EFE6DA',
+          primaryTextColor: '#1E1A17',
+          primaryBorderColor: '#E6DED3',
+          lineColor: '#9A5A2E',
+          secondaryColor: '#FCFBF8',
+          tertiaryColor: '#F7F4EF',
+          fontFamily: 'Inter, system-ui, sans-serif',
+          fontSize: '14px',
+        },
+      });
+      await mermaid.run({ querySelector: '.mermaid' });
+    `;
+    document.head.appendChild(script);
+  }
+</script>


### PR DESCRIPTION
## Summary
- Replaces client-side password gate with real GitHub OAuth flow
- Adds four Vercel Edge Functions in `site/api/auth/` (github, callback, session, logout)
- Only verified repo collaborators (GitHub API 204 check) can complete login
- Session stored as HMAC-SHA256-signed httpOnly cookie, expires after 24 hours

## How it works
1. `/admin` loads and calls `/api/auth/session` (Edge fn reads cookie server-side)
2. If unauthenticated → redirected to `/api/auth/github` → GitHub OAuth consent
3. Callback at `/api/auth/callback` exchanges code, verifies collaborator status, sets signed cookie
4. On return: session check passes, content shown
5. Logout hits `/api/auth/logout` which clears cookie and redirects home

## Prerequisites (already done)
- [x] GitHub OAuth App "Professional Site Admin" created, callback URL registered
- [x] `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `SESSION_SECRET` added to Vercel env vars

## Test plan
- [ ] Visit `/admin` without a session — should redirect to GitHub OAuth
- [ ] Complete OAuth as `rainonej` — should land on `/admin` with content visible
- [ ] Try OAuth as a non-collaborator GitHub account — should get 403
- [ ] Verify session persists across page refreshes (within 24h)
- [ ] Click Log out — should clear cookie and redirect to home

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)