### PR TITLE
docs: document /admin (Vercel OAuth) in README, CONTRIBUTING, ai-workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,6 +235,22 @@ npm install            # also installs the husky pre-commit hook
 
 This also installs the pre-commit hook (husky + lint-staged), which runs Prettier and ESLint on staged files before every commit. If hooks stop firing, re-run `npm install`.
 
+### Setting up the admin page
+
+The `/admin` route uses **GitHub OAuth** on Vercel. Only users who are **collaborators** on `rainonej/profesional_site` can complete login (enforced server-side after OAuth).
+
+1. **Create a GitHub OAuth App** at [github.com/settings/developers](https://github.com/settings/developers) (Developer settings → OAuth Apps → New OAuth App).
+   - **Application name:** e.g. `profesional-site-admin` (your choice).
+   - **Homepage URL:** your Vercel project URL, e.g. `https://profesional-site.vercel.app`.
+   - **Authorization callback URL:** `https://profesional-site.vercel.app/api/auth/callback` (use the same origin as the deployment where you test; Preview deployments need a matching callback URL in the OAuth app or a second OAuth app per environment).
+2. **Add environment variables** in the Vercel project (**Settings → Environment Variables**), for **Production** and **Preview** as needed:
+   - `GITHUB_CLIENT_ID` — from the OAuth app.
+   - `GITHUB_CLIENT_SECRET` — from the OAuth app.
+   - `SESSION_SECRET` — a long random string used to sign session cookies (generate locally; do not commit it).
+3. **Redeploy** the project, then open `/admin` on Vercel and choose **Continue with GitHub** (or the equivalent sign-in). After authorizing, you should land on the admin overview.
+
+Local development: OAuth callbacks require a public HTTPS URL that matches your OAuth app; use a Vercel Preview deployment or tunnel, or rely on the deployed preview for admin testing.
+
 ### Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ The live site reflects `main`. The public preview reflects `dev` and updates wit
 
 The site includes a private **Admin** page for maintainers: live design tokens (color swatches from CSS variables), typography samples, interactive UI previews, and a Mermaid diagram of site routes. It is meant for design review and orientation, not public visitors.
 
-- **URL (Vercel preview / production host):** <https://profesional-site.vercel.app/admin>
-- **Hosting:** The admin page only runs on **Vercel** (server routes for GitHub OAuth and session cookies). It is **not** deployed to the GitHub Pages production URL (`rainonej.github.io/...`).
+- **URLs:** The admin page only runs on **Vercel** (server routes for GitHub OAuth and session cookies), not on GitHub Pages (`rainonej.github.io/...`). It is available on both Production and Preview origins — e.g. <https://profesional-site.vercel.app/admin> on the public Production alias. **Vercel’s comment toolbar** (pin comments, convert to GitHub issues) appears only on **Preview** deployments, not on that Production host. For feedback that uses the toolbar **and** the admin overview, open **`/admin` on the review preview:** <https://profesional-site-git-dev-rainonejs-projects.vercel.app/admin> (see [CONTRIBUTING.md — Vercel environments](CONTRIBUTING.md#vercel-environments)).
 
 See [CONTRIBUTING.md — Setting up the admin page](CONTRIBUTING.md#setting-up-the-admin-page) for OAuth and environment variables.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ The live site reflects `main`. The public preview reflects `dev` and updates wit
 
 ---
 
+## Admin page (`/admin`)
+
+The site includes a private **Admin** page for maintainers: live design tokens (color swatches from CSS variables), typography samples, interactive UI previews, and a Mermaid diagram of site routes. It is meant for design review and orientation, not public visitors.
+
+- **URL (Vercel preview / production host):** <https://profesional-site.vercel.app/admin>
+- **Hosting:** The admin page only runs on **Vercel** (server routes for GitHub OAuth and session cookies). It is **not** deployed to the GitHub Pages production URL (`rainonej.github.io/...`).
+
+See [CONTRIBUTING.md — Setting up the admin page](CONTRIBUTING.md#setting-up-the-admin-page) for OAuth and environment variables.
+
+---
+
 ## Repository structure
 
 ```text

--- a/docs/ai-workflows.md
+++ b/docs/ai-workflows.md
@@ -80,7 +80,7 @@ Issues come from three places:
 | **Human-opened GitHub issues** | Developer or site owner opens an issue directly → add `source:human` |
 | **CMS** | Reserved; not currently active |
 
-**Vercel comments and `/admin`:** For design and content change requests, Agreni should open **`/admin` on the Vercel deployment** (<https://profesional-site.vercel.app/admin>) as the intended page from which to use the **Vercel comment toolbar** (pin comments on any part of the preview, then convert to GitHub issues). That keeps feedback on the Vercel-hosted site alongside the private admin overview (design tokens, typography, site map). The admin route is not available on GitHub Pages.
+**Vercel comments and `/admin`:** The comment toolbar is only available on **Preview** deployments, not on Vercel’s Production alias. For design and content change requests, Agreni should open **`/admin` on the review preview** (<https://profesional-site-git-dev-rainonejs-projects.vercel.app/admin>) so the **Vercel comment toolbar** and the private admin overview (design tokens, typography, site map) are on the same origin. Pin comments on the preview, then convert to GitHub issues. See [CONTRIBUTING.md — Vercel environments](../CONTRIBUTING.md#vercel-environments). The admin route is not available on GitHub Pages.
 
 ---
 

--- a/docs/ai-workflows.md
+++ b/docs/ai-workflows.md
@@ -80,6 +80,8 @@ Issues come from three places:
 | **Human-opened GitHub issues** | Developer or site owner opens an issue directly → add `source:human` |
 | **CMS** | Reserved; not currently active |
 
+**Vercel comments and `/admin`:** For design and content change requests, Agreni should open **`/admin` on the Vercel deployment** (<https://profesional-site.vercel.app/admin>) as the intended page from which to use the **Vercel comment toolbar** (pin comments on any part of the preview, then convert to GitHub issues). That keeps feedback on the Vercel-hosted site alongside the private admin overview (design tokens, typography, site map). The admin route is not available on GitHub Pages.
+
 ---
 
 ## The planner


### PR DESCRIPTION
Implements [issue #152](https://github.com/rainonej/profesional_site/issues/152): README admin section with Vercel link, CONTRIBUTING OAuth setup (env vars + collaborators), and \docs/ai-workflows.md\ note on using \/admin\ for the Vercel comment workflow.

Closes #152

Made with [Cursor](https://cursor.com)