### PR TITLE
fix(ci): PAT for auto-update PR branches so CI retriggers (#68)

### DIFF
--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -1,6 +1,16 @@
 # When dev advances, auto-update all open PRs targeting dev so auto-merge can fire.
 # Solves the "branch is BEHIND" stall caused by branch protection strict: true.
 # See issue #68.
+#
+# Uses WORKFLOW_TRIGGER_PAT (not GITHUB_TOKEN) for pulls.updateBranch because GitHub
+# does not run new workflows for events caused by the default GITHUB_TOKEN. Without a
+# PAT, PR heads get updated but CI never re-runs → merge stays "blocked" until someone
+# pushes again. Docs:
+# https://docs.github.com/en/actions/security-for-github-actions/security-guides/
+# automatic-token-authentication#using-the-github_token-in-a-workflow
+#
+# Secret: fine-grained PAT on this repo with Contents + Pull requests read/write
+# (or classic PAT with `repo`). Add at Settings → Secrets → Actions.
 name: Auto-update PR branches
 
 on:
@@ -11,13 +21,24 @@ jobs:
   update-branches:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     steps:
+      - name: Require WORKFLOW_TRIGGER_PAT
+        run: |
+          if [ -z "$WORKFLOW_TRIGGER_PAT" ]; then
+            echo "::error::WORKFLOW_TRIGGER_PAT Actions secret is not set."
+            echo "Add a fine-grained PAT: Contents + Pull requests (read/write) on this repo."
+            echo "Required so CI re-runs after updating PR branches (GITHUB_TOKEN does not)."
+            exit 1
+          fi
+        env:
+          WORKFLOW_TRIGGER_PAT: ${{ secrets.WORKFLOW_TRIGGER_PAT }}
+
       - name: Update open PRs targeting dev
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.WORKFLOW_TRIGGER_PAT }}
           script: |
             const { data: pulls } = await github.rest.pulls.list({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
Switches **Auto-update PR branches** to use repository secret \WORKFLOW_TRIGGER_PAT\ for \pulls.updateBranch\, because merges performed with the default \GITHUB_TOKEN\ do not trigger new workflow runs (so required checks stay stale and auto-merge stalls).

## Setup (repo admin)
Add **Settings → Secrets and variables → Actions → New repository secret**:
- **Name:** \WORKFLOW_TRIGGER_PAT\
- **Value:** Fine-grained PAT scoped to this repo with **Contents** and **Pull requests** (read/write), or classic PAT with \epo\.

Until the secret exists, this workflow fails fast with a clear error on each \dev\ push (so we do not silently reintroduce the stall).

## Issue
Refs #68.

Made with [Cursor](https://cursor.com)