### PR TITLE
fix(nav): move Admin link from top nav to footer

### DIFF
--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -1,11 +1,5 @@
 ---
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const adminOriginEnv =
-  import.meta.env.PUBLIC_ADMIN_ORIGIN?.trim().replace(/\/$/, '') ?? '';
-// GitHub Pages uses a repo base path; OAuth is Vercel-only — use the public preview origin unless overridden.
-const adminOrigin =
-  adminOriginEnv || (base !== '' ? 'https://profesional-site.vercel.app' : '');
-const adminHref = adminOrigin ? `${adminOrigin}/admin` : `${base}/admin`;
 
 function isNavActive(pathname: string, href: string): boolean {
   if (href.startsWith('http://') || href.startsWith('https://')) {
@@ -24,7 +18,6 @@ const links = [
   { href: `${base}/writing`, label: 'Writing' },
   { href: `${base}/work`, label: 'Work' },
   { href: `${base}/contact`, label: 'Contact' },
-  { href: adminHref, label: 'Admin' },
 ];
 
 const { pathname } = Astro.url;

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -13,6 +13,11 @@ interface Props {
 const { title, description = 'Personal website', ogImage, ogUrl } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const site = import.meta.env.SITE ?? 'https://rainonej.github.io';
+const adminOriginEnv =
+  import.meta.env.PUBLIC_ADMIN_ORIGIN?.trim().replace(/\/$/, '') ?? '';
+const adminOrigin =
+  adminOriginEnv || (base !== '' ? 'https://profesional-site.vercel.app' : '');
+const adminHref = adminOrigin ? `${adminOrigin}/admin` : `${base}/admin`;
 const canonicalUrl = ogUrl ?? `${site}${base}${Astro.url.pathname}`;
 const imageUrl = ogImage
   ? ogImage.startsWith('http')
@@ -65,7 +70,12 @@ const imageUrl = ogImage
     <footer
       class="mt-24 border-t border-stone-100 px-6 py-10 text-center text-sm text-stone-400"
     >
-      <p>© {new Date().getFullYear()} Agreni &middot; Made with care</p>
+      <p>
+        © {new Date().getFullYear()} Agreni &middot; Made with care &middot; <a
+          href={adminHref}
+          class="transition-colors hover:text-stone-600">Admin</a
+        >
+      </p>
     </footer>
     <script is:inline>
       const observer = new IntersectionObserver(


### PR DESCRIPTION
Admin is a private page — only for Jordan and Agreni. It shouldn't sit in the top nav alongside About, Writing, Work, Contact.

**Change:** removed Admin from the nav link list; added a subtle text link in the footer next to "© Agreni · Made with care":

```
© 2026 Agreni · Made with care · Admin
```

The Admin origin logic (GitHub Pages base-path handling, `PUBLIC_ADMIN_ORIGIN` env var) moved from `Nav.astro` to `Layout.astro` so the footer link resolves correctly in all environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)