### PR TITLE
feat(admin): add image drag-and-drop upload to repo media

### DIFF
--- a/site/src/pages/admin.astro
+++ b/site/src/pages/admin.astro
@@ -1098,6 +1098,37 @@ function fmtDate(d: Date) {
     font-size: 0.875rem;
   }
 
+  /* ── Body file drop zone ─────────────────────────────────────────────── */
+  .body-drop-zone {
+    position: relative;
+  }
+
+  .body-drop-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px dashed var(--copper);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.88);
+    font-size: 0.9375rem;
+    font-weight: 500;
+    color: var(--copper);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  .body-drop-zone.dragging .body-drop-overlay {
+    opacity: 1;
+  }
+
+  .body-drop-zone.dragging .drawer-textarea-body {
+    border-color: var(--copper);
+    border-style: dashed;
+  }
+
   .drawer-checkbox-row {
     display: flex;
     align-items: center;
@@ -1520,6 +1551,7 @@ function fmtDate(d: Date) {
     drawerDeleteBtn.disabled = false;
     _onSave = opts.onSave;
     _onDelete = opts.onDelete ?? null;
+    initBodyFileDrop();
     openDrawer();
     drawerFieldsEl.scrollTop = 0;
   }
@@ -1545,9 +1577,13 @@ function fmtDate(d: Date) {
         if (f.type === 'textarea') {
           const isBody = f.name === 'body';
           const extraClass = isBody ? ' drawer-textarea-body' : '';
+          const ta = `<textarea id="${id}" name="${f.name}" class="drawer-input drawer-textarea${extraClass}">${safeVal}</textarea>`;
+          const inner = isBody
+            ? `<div class="body-drop-zone">${ta}<div class="body-drop-overlay" aria-hidden="true">Drop .txt or .md here</div></div>`
+            : ta;
           return `<div class="drawer-field">
             <label class="drawer-label" for="${id}">${f.label}</label>
-            <textarea id="${id}" name="${f.name}" class="drawer-input drawer-textarea${extraClass}">${safeVal}</textarea>
+            ${inner}
           </div>`;
         }
         return `<div class="drawer-field">
@@ -1569,6 +1605,71 @@ function fmtDate(d: Date) {
         inp.type === 'checkbox' ? (inp as HTMLInputElement).checked : inp.value;
     }
     return result;
+  }
+
+  // ── Body file drop (.txt / .md) ──────────────────────────────────────
+  function initBodyFileDrop() {
+    const textarea =
+      drawerFieldsEl.querySelector<HTMLTextAreaElement>('#df-body');
+    if (!textarea) return;
+
+    const zone = textarea.closest<HTMLElement>('.body-drop-zone');
+    if (!zone) return;
+
+    let dragCounter = 0;
+
+    textarea.addEventListener('dragenter', (e) => {
+      e.preventDefault();
+      dragCounter++;
+      zone.classList.add('dragging');
+    });
+
+    textarea.addEventListener('dragleave', () => {
+      dragCounter--;
+      if (dragCounter <= 0) {
+        dragCounter = 0;
+        zone.classList.remove('dragging');
+      }
+    });
+
+    textarea.addEventListener('dragover', (e) => {
+      e.preventDefault();
+    });
+
+    textarea.addEventListener('drop', (e) => {
+      e.preventDefault();
+      dragCounter = 0;
+      zone.classList.remove('dragging');
+
+      const file = e.dataTransfer?.files[0];
+      if (!file) return;
+
+      const ext = file.name.split('.').pop()?.toLowerCase();
+      if (ext !== 'txt' && ext !== 'md') {
+        showToast(
+          'Only .txt and .md files can be dropped on the body field',
+          true
+        );
+        return;
+      }
+
+      if (
+        textarea.value.trim() &&
+        !confirm('Replace existing body with the dropped file?')
+      ) {
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        textarea.value = reader.result as string;
+        showToast(`Body loaded from ${file.name}`);
+      };
+      reader.onerror = () => {
+        showToast('Failed to read file', true);
+      };
+      reader.readAsText(file, 'UTF-8');
+    });
   }
 
   // ── Content buttons wiring ───────────────────────────────────────────

--- a/site/src/pages/admin.astro
+++ b/site/src/pages/admin.astro
@@ -1579,7 +1579,7 @@ function fmtDate(d: Date) {
           const extraClass = isBody ? ' drawer-textarea-body' : '';
           const ta = `<textarea id="${id}" name="${f.name}" class="drawer-input drawer-textarea${extraClass}">${safeVal}</textarea>`;
           const inner = isBody
-            ? `<div class="body-drop-zone">${ta}<div class="body-drop-overlay" aria-hidden="true">Drop .txt or .md here</div></div>`
+            ? `<div class="body-drop-zone">${ta}<div class="body-drop-overlay" aria-hidden="true">Drop .txt, .md, or .docx here</div></div>`
             : ta;
           return `<div class="drawer-field">
             <label class="drawer-label" for="${id}">${f.label}</label>
@@ -1607,7 +1607,21 @@ function fmtDate(d: Date) {
     return result;
   }
 
-  // ── Body file drop (.txt / .md) ──────────────────────────────────────
+  // ── Body file drop (.txt / .md / .docx) ─────────────────────────────
+  type MammothModule = {
+    convertToMarkdown: (
+      input: { arrayBuffer: ArrayBuffer },
+      options?: object
+    ) => Promise<{ value: string; messages: { message: string }[] }>;
+  };
+
+  async function loadMammoth(): Promise<MammothModule> {
+    const w = window as Window & { mammoth?: MammothModule };
+    if (w.mammoth) return w.mammoth;
+    await import('https://cdn.jsdelivr.net/npm/mammoth@1/mammoth.browser.min.js');
+    return w.mammoth!;
+  }
+
   function initBodyFileDrop() {
     const textarea =
       drawerFieldsEl.querySelector<HTMLTextAreaElement>('#df-body');
@@ -1645,9 +1659,9 @@ function fmtDate(d: Date) {
       if (!file) return;
 
       const ext = file.name.split('.').pop()?.toLowerCase();
-      if (ext !== 'txt' && ext !== 'md') {
+      if (ext !== 'txt' && ext !== 'md' && ext !== 'docx') {
         showToast(
-          'Only .txt and .md files can be dropped on the body field',
+          'Only .txt, .md, and .docx files can be dropped on the body field',
           true
         );
         return;
@@ -1660,15 +1674,44 @@ function fmtDate(d: Date) {
         return;
       }
 
-      const reader = new FileReader();
-      reader.onload = () => {
-        textarea.value = reader.result as string;
-        showToast(`Body loaded from ${file.name}`);
-      };
-      reader.onerror = () => {
-        showToast('Failed to read file', true);
-      };
-      reader.readAsText(file, 'UTF-8');
+      if (ext === 'docx') {
+        textarea.value = 'Converting…';
+        const reader = new FileReader();
+        reader.onload = async () => {
+          try {
+            const mammoth = await loadMammoth();
+            const result = await mammoth.convertToMarkdown({
+              arrayBuffer: reader.result as ArrayBuffer,
+            });
+            textarea.value = result.value;
+            if (result.messages.length > 0) {
+              showToast(
+                `Converted from ${file.name} — review formatting (${result.messages.length} warning${result.messages.length > 1 ? 's' : ''})`
+              );
+            } else {
+              showToast(`Converted from ${file.name} — review formatting`);
+            }
+          } catch (err: unknown) {
+            textarea.value = '';
+            showToast('Conversion failed: ' + (err as Error).message, true);
+          }
+        };
+        reader.onerror = () => {
+          textarea.value = '';
+          showToast('Failed to read file', true);
+        };
+        reader.readAsArrayBuffer(file);
+      } else {
+        const reader = new FileReader();
+        reader.onload = () => {
+          textarea.value = reader.result as string;
+          showToast(`Body loaded from ${file.name}`);
+        };
+        reader.onerror = () => {
+          showToast('Failed to read file', true);
+        };
+        reader.readAsText(file, 'UTF-8');
+      }
     });
   }
 

--- a/site/src/pages/admin.astro
+++ b/site/src/pages/admin.astro
@@ -680,27 +680,37 @@ function fmtDate(d: Date) {
     </div>
   </div>
 
-  <!-- ── Edit modal ──────────────────────────────────────────────────────── -->
-  <dialog id="edit-modal" class="edit-modal">
-    <div class="modal-inner">
-      <div class="modal-header">
-        <h2 id="modal-title" class="modal-title"></h2>
-        <button id="modal-close-btn" class="modal-close" aria-label="Close"
+  <!-- ── Edit drawer ──────────────────────────────────────────────────────── -->
+  <div id="drawer-backdrop" class="drawer-backdrop"></div>
+  <div
+    id="edit-drawer"
+    class="edit-drawer"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="drawer-title"
+  >
+    <div class="drawer-inner">
+      <div class="drawer-header">
+        <h2 id="drawer-title" class="drawer-title"></h2>
+        <button id="drawer-close-btn" class="drawer-close" aria-label="Close"
           >✕</button
         >
       </div>
-      <div id="modal-fields" class="modal-fields"></div>
-      <div class="modal-footer">
-        <button id="modal-save-btn" class="admin-save-btn">Save</button>
+      <div id="drawer-fields" class="drawer-fields"></div>
+      <div class="drawer-footer">
         <button
-          id="modal-delete-btn"
+          id="drawer-delete-btn"
           class="admin-delete-btn"
           style="display:none">Delete</button
         >
-        <button id="modal-cancel-btn" class="admin-cancel-btn">Cancel</button>
+        <div class="drawer-footer-actions">
+          <button id="drawer-save-btn" class="admin-save-btn">Save</button>
+          <button id="drawer-cancel-btn" class="admin-cancel-btn">Cancel</button
+          >
+        </div>
       </div>
     </div>
-  </dialog>
+  </div>
 
   <!-- ── Toast ───────────────────────────────────────────────────────────── -->
   <div id="toast" role="status" aria-live="polite"></div>
@@ -897,17 +907,19 @@ function fmtDate(d: Date) {
   .admin-field-label {
     display: flex;
     flex-direction: column;
-    font-size: 0.75rem;
-    color: var(--stone-soft);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--ink);
+    margin-bottom: 6px;
   }
 
   .admin-input {
     margin-top: 4px;
-    padding: 8px 10px;
+    padding: 10px 12px;
     border: 1px solid var(--warm-line);
-    border-radius: 8px;
+    border-radius: 10px;
     background: var(--paper);
-    font-size: 0.875rem;
+    font-size: 0.9375rem;
     color: var(--ink);
     outline: none;
     transition: border-color 0.15s;
@@ -920,79 +932,115 @@ function fmtDate(d: Date) {
   .admin-textarea {
     resize: vertical;
     font-family: inherit;
-    line-height: 1.5;
+    line-height: 1.6;
+    min-height: 120px;
   }
 
-  /* ── Edit modal ─────────────────────────────────────────────────────── */
-  .edit-modal {
-    border: none;
-    border-radius: 20px;
-    padding: 0;
-    max-width: min(680px, calc(100vw - 32px));
-    width: 100%;
-    max-height: calc(100vh - 64px);
-    overflow: hidden;
-    box-shadow:
-      0 20px 60px rgba(0, 0, 0, 0.15),
-      0 4px 16px rgba(0, 0, 0, 0.08);
-  }
-
-  .edit-modal::backdrop {
-    background: rgba(0, 0, 0, 0.35);
+  /* ── Edit drawer ─────────────────────────────────────────────────────── */
+  .drawer-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(2px);
+    z-index: 40;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+  }
+  .drawer-backdrop.open {
+    opacity: 1;
+    pointer-events: auto;
   }
 
-  .modal-inner {
+  .edit-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100vh;
+    width: min(720px, 100vw);
+    z-index: 50;
+    transform: translateX(100%);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     display: flex;
     flex-direction: column;
-    max-height: calc(100vh - 64px);
+    background: var(--paper);
+    box-shadow: -4px 0 40px rgba(0, 0, 0, 0.12);
+  }
+  .edit-drawer.open {
+    transform: translateX(0);
   }
 
-  .modal-header {
+  .drawer-inner {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .drawer-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 12px;
     padding: 20px 24px 16px;
     border-bottom: 1px solid var(--warm-line);
     background: var(--paper-light);
     flex-shrink: 0;
   }
 
-  .modal-title {
+  .drawer-title {
     font-family: var(--font-serif, serif);
     font-size: 1.25rem;
     font-weight: 700;
     color: var(--ink);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
-  .modal-close {
-    width: 28px;
-    height: 28px;
+  .drawer-close {
+    width: 32px;
+    height: 32px;
     border-radius: 50%;
     border: 1px solid var(--warm-line);
     background: transparent;
-    font-size: 0.75rem;
+    font-size: 0.875rem;
     color: var(--stone-soft);
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: color 0.15s;
+    flex-shrink: 0;
   }
-  .modal-close:hover {
+  .drawer-close:hover {
     color: var(--ink);
   }
 
-  .modal-fields {
-    padding: 20px 24px;
+  @media (max-width: 640px) {
+    .drawer-close::before {
+      content: '← ';
+      font-size: 1rem;
+    }
+    .drawer-close {
+      width: auto;
+      border-radius: 6px;
+      padding: 4px 10px;
+      font-size: 0.875rem;
+    }
+  }
+
+  .drawer-fields {
+    padding: 24px;
     overflow-y: auto;
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 18px;
   }
 
-  .modal-footer {
+  .drawer-footer {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -1002,50 +1050,65 @@ function fmtDate(d: Date) {
     flex-shrink: 0;
   }
 
-  /* Modal field styles */
-  .modal-field {
+  .drawer-footer-actions {
+    display: flex;
+    gap: 8px;
+    margin-left: auto;
+  }
+
+  /* Drawer field styles */
+  .drawer-field {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 6px;
   }
 
-  .modal-label {
-    font-size: 0.75rem;
-    color: var(--stone-soft);
+  .drawer-label {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--ink);
+    margin-bottom: 2px;
   }
 
-  .modal-input {
-    padding: 8px 10px;
+  .drawer-input {
+    padding: 10px 12px;
     border: 1px solid var(--warm-line);
-    border-radius: 8px;
+    border-radius: 10px;
     background: var(--paper);
-    font-size: 0.875rem;
+    font-size: 0.9375rem;
     color: var(--ink);
     outline: none;
     transition: border-color 0.15s;
     width: 100%;
     font-family: inherit;
   }
-  .modal-input:focus {
+  .drawer-input:focus {
     border-color: var(--copper);
   }
 
-  .modal-textarea {
+  .drawer-textarea {
     resize: vertical;
-    line-height: 1.5;
+    line-height: 1.6;
+    min-height: 120px;
   }
 
-  .modal-checkbox-row {
+  .drawer-textarea-body {
+    min-height: 320px;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.875rem;
+  }
+
+  .drawer-checkbox-row {
     display: flex;
     align-items: center;
-    gap: 8px;
-    font-size: 0.875rem;
+    gap: 10px;
+    font-size: 0.9375rem;
     color: var(--ink);
     cursor: pointer;
   }
-  .modal-checkbox-row input[type='checkbox'] {
-    width: 16px;
-    height: 16px;
+  .drawer-checkbox-row input[type='checkbox'] {
+    width: 18px;
+    height: 18px;
     accent-color: var(--copper);
   }
 
@@ -1364,18 +1427,19 @@ function fmtDate(d: Date) {
     }, 4000);
   }
 
-  // ── Modal ──────────────────────────────────────────────────────────────
-  const modalEl = document.getElementById('edit-modal') as HTMLDialogElement;
-  const modalTitleEl = document.getElementById('modal-title')!;
-  const modalFieldsEl = document.getElementById('modal-fields')!;
-  const modalSaveBtn = document.getElementById(
-    'modal-save-btn'
+  // ── Drawer ─────────────────────────────────────────────────────────────
+  const drawerEl = document.getElementById('edit-drawer')!;
+  const drawerBackdrop = document.getElementById('drawer-backdrop')!;
+  const drawerTitleEl = document.getElementById('drawer-title')!;
+  const drawerFieldsEl = document.getElementById('drawer-fields')!;
+  const drawerSaveBtn = document.getElementById(
+    'drawer-save-btn'
   ) as HTMLButtonElement;
-  const modalDeleteBtn = document.getElementById(
-    'modal-delete-btn'
+  const drawerDeleteBtn = document.getElementById(
+    'drawer-delete-btn'
   ) as HTMLButtonElement;
-  const modalCancelBtn = document.getElementById('modal-cancel-btn')!;
-  const modalCloseBtn = document.getElementById('modal-close-btn')!;
+  const drawerCancelBtn = document.getElementById('drawer-cancel-btn')!;
+  const drawerCloseBtn = document.getElementById('drawer-close-btn')!;
 
   type FieldDef = {
     name: string;
@@ -1388,42 +1452,57 @@ function fmtDate(d: Date) {
   let _onSave: ((vals: Record<string, unknown>) => Promise<void>) | null = null;
   let _onDelete: (() => Promise<void>) | null = null;
 
+  function openDrawer() {
+    drawerEl.classList.add('open');
+    drawerBackdrop.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeDrawer() {
+    drawerEl.classList.remove('open');
+    drawerBackdrop.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
   function initModal() {
-    modalSaveBtn.addEventListener('click', async () => {
+    drawerSaveBtn.addEventListener('click', async () => {
       if (!_onSave) return;
-      modalSaveBtn.disabled = true;
-      modalSaveBtn.textContent = 'Saving…';
+      drawerSaveBtn.disabled = true;
+      drawerSaveBtn.textContent = 'Saving…';
       try {
-        await _onSave(readModalForm());
-        modalEl.close();
+        await _onSave(readDrawerForm());
+        closeDrawer();
         showToast('Saved — committed to dev');
         window.location.reload();
       } catch (e: unknown) {
         showToast((e as Error).message, true);
-        modalSaveBtn.disabled = false;
-        modalSaveBtn.textContent = 'Save';
+        drawerSaveBtn.disabled = false;
+        drawerSaveBtn.textContent = 'Save';
       }
     });
 
-    modalDeleteBtn.addEventListener('click', async () => {
+    drawerDeleteBtn.addEventListener('click', async () => {
       if (!_onDelete) return;
       if (!confirm('Delete this entry? This cannot be undone.')) return;
-      modalDeleteBtn.disabled = true;
+      drawerDeleteBtn.disabled = true;
       try {
         await _onDelete();
-        modalEl.close();
+        closeDrawer();
         showToast('Deleted — committed to dev');
         window.location.reload();
       } catch (e: unknown) {
         showToast((e as Error).message, true);
-        modalDeleteBtn.disabled = false;
+        drawerDeleteBtn.disabled = false;
       }
     });
 
-    modalCancelBtn.addEventListener('click', () => modalEl.close());
-    modalCloseBtn.addEventListener('click', () => modalEl.close());
-    modalEl.addEventListener('click', (e) => {
-      if (e.target === modalEl) modalEl.close();
+    drawerCancelBtn.addEventListener('click', closeDrawer);
+    drawerCloseBtn.addEventListener('click', closeDrawer);
+    drawerBackdrop.addEventListener('click', closeDrawer);
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && drawerEl.classList.contains('open')) {
+        closeDrawer();
+      }
     });
   }
 
@@ -1433,21 +1512,22 @@ function fmtDate(d: Date) {
     onSave: (vals: Record<string, unknown>) => Promise<void>;
     onDelete?: () => Promise<void>;
   }) {
-    modalTitleEl.textContent = opts.title;
-    modalFieldsEl.innerHTML = renderFields(opts.fields);
-    modalSaveBtn.disabled = false;
-    modalSaveBtn.textContent = 'Save';
-    modalDeleteBtn.style.display = opts.onDelete ? 'block' : 'none';
-    modalDeleteBtn.disabled = false;
+    drawerTitleEl.textContent = opts.title;
+    drawerFieldsEl.innerHTML = renderFields(opts.fields);
+    drawerSaveBtn.disabled = false;
+    drawerSaveBtn.textContent = 'Save';
+    drawerDeleteBtn.style.display = opts.onDelete ? 'block' : 'none';
+    drawerDeleteBtn.disabled = false;
     _onSave = opts.onSave;
     _onDelete = opts.onDelete ?? null;
-    modalEl.showModal();
+    openDrawer();
+    drawerFieldsEl.scrollTop = 0;
   }
 
   function renderFields(fields: FieldDef[]): string {
     return fields
       .map((f) => {
-        const id = `mf-${f.name}`;
+        const id = `df-${f.name}`;
         const safeVal = String(f.value ?? '')
           .replace(/&/g, '&amp;')
           .replace(/</g, '&lt;')
@@ -1455,31 +1535,33 @@ function fmtDate(d: Date) {
           .replace(/"/g, '&quot;');
 
         if (f.type === 'checkbox') {
-          return `<div class="modal-field">
-            <label class="modal-checkbox-row">
+          return `<div class="drawer-field">
+            <label class="drawer-checkbox-row">
               <input type="checkbox" id="${id}" name="${f.name}" ${f.value ? 'checked' : ''}>
               ${f.label}
             </label>
           </div>`;
         }
         if (f.type === 'textarea') {
-          return `<div class="modal-field">
-            <label class="modal-label" for="${id}">${f.label}</label>
-            <textarea id="${id}" name="${f.name}" class="modal-input modal-textarea" rows="${f.rows ?? 4}">${safeVal}</textarea>
+          const isBody = f.name === 'body';
+          const extraClass = isBody ? ' drawer-textarea-body' : '';
+          return `<div class="drawer-field">
+            <label class="drawer-label" for="${id}">${f.label}</label>
+            <textarea id="${id}" name="${f.name}" class="drawer-input drawer-textarea${extraClass}">${safeVal}</textarea>
           </div>`;
         }
-        return `<div class="modal-field">
-          <label class="modal-label" for="${id}">${f.label}</label>
-          <input type="${f.type ?? 'text'}" id="${id}" name="${f.name}" class="modal-input" value="${safeVal}">
+        return `<div class="drawer-field">
+          <label class="drawer-label" for="${id}">${f.label}</label>
+          <input type="${f.type ?? 'text'}" id="${id}" name="${f.name}" class="drawer-input" value="${safeVal}">
         </div>`;
       })
       .join('');
   }
 
-  function readModalForm(): Record<string, unknown> {
+  function readDrawerForm(): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const el of Array.from(
-      modalFieldsEl.querySelectorAll('input, textarea, select')
+      drawerFieldsEl.querySelectorAll('input, textarea, select')
     )) {
       const inp = el as HTMLInputElement | HTMLTextAreaElement;
       if (!inp.name) continue;

--- a/site/src/pages/admin.astro
+++ b/site/src/pages/admin.astro
@@ -1129,6 +1129,61 @@ function fmtDate(d: Date) {
     border-style: dashed;
   }
 
+  /* ── Image upload drop zone ──────────────────────────────────────────── */
+  .img-drop-zone {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 8px;
+    padding: 12px 16px;
+    border: 1px dashed var(--warm-line);
+    border-radius: 10px;
+    background: var(--paper-light);
+    cursor: pointer;
+    transition:
+      border-color 0.15s,
+      background 0.15s;
+    position: relative;
+  }
+  .img-drop-zone:hover,
+  .img-drop-zone.dragging {
+    border-color: var(--copper);
+    background: var(--pale-sand);
+  }
+  .img-drop-zone.uploading {
+    opacity: 0.6;
+    cursor: wait;
+    pointer-events: none;
+  }
+
+  .img-drop-label {
+    font-size: 0.8125rem;
+    color: var(--stone-soft);
+    pointer-events: none;
+  }
+
+  .img-drop-file-input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+  }
+
+  .img-preview {
+    margin-top: 8px;
+  }
+
+  .img-preview-thumb {
+    max-height: 120px;
+    max-width: 100%;
+    border-radius: 8px;
+    border: 1px solid var(--warm-line);
+    object-fit: cover;
+  }
+
   .drawer-checkbox-row {
     display: flex;
     align-items: center;
@@ -1478,6 +1533,7 @@ function fmtDate(d: Date) {
     type?: string;
     rows?: number;
     value?: unknown;
+    uploadCollection?: string;
   };
 
   let _onSave: ((vals: Record<string, unknown>) => Promise<void>) | null = null;
@@ -1552,6 +1608,7 @@ function fmtDate(d: Date) {
     _onSave = opts.onSave;
     _onDelete = opts.onDelete ?? null;
     initBodyFileDrop();
+    initImageUpload();
     openDrawer();
     drawerFieldsEl.scrollTop = 0;
   }
@@ -1584,6 +1641,19 @@ function fmtDate(d: Date) {
           return `<div class="drawer-field">
             <label class="drawer-label" for="${id}">${f.label}</label>
             ${inner}
+          </div>`;
+        }
+        if (f.uploadCollection) {
+          return `<div class="drawer-field">
+            <label class="drawer-label" for="${id}">${f.label}</label>
+            <input type="text" id="${id}" name="${f.name}" class="drawer-input" value="${safeVal}" placeholder="/media/${f.uploadCollection}/filename.jpg">
+            <div class="img-drop-zone" data-collection="${f.uploadCollection}" data-field="${id}">
+              <span class="img-drop-label">Drop image here or click to browse</span>
+              <input type="file" class="img-drop-file-input" accept=".jpg,.jpeg,.png,.webp,.gif" aria-label="Upload image">
+            </div>
+            <div class="img-preview" style="display:none">
+              <img class="img-preview-thumb" src="" alt="Preview">
+            </div>
           </div>`;
         }
         return `<div class="drawer-field">
@@ -1715,6 +1785,108 @@ function fmtDate(d: Date) {
     });
   }
 
+  // ── Image upload drop zone ────────────────────────────────────────────
+  function initImageUpload() {
+    const zones =
+      drawerFieldsEl.querySelectorAll<HTMLElement>('.img-drop-zone');
+    zones.forEach((zone) => {
+      const collection = zone.dataset['collection']!;
+      const fieldId = zone.dataset['field']!;
+      const pathInput = drawerFieldsEl.querySelector<HTMLInputElement>(
+        `#${fieldId}`
+      );
+      const previewEl = zone.nextElementSibling as HTMLElement | null;
+      const previewImg =
+        previewEl?.querySelector<HTMLImageElement>('.img-preview-thumb');
+      const fileInput = zone.querySelector<HTMLInputElement>(
+        '.img-drop-file-input'
+      );
+
+      if (!pathInput || !previewEl || !previewImg || !fileInput) return;
+
+      const ALLOWED_EXTS = ['jpg', 'jpeg', 'png', 'webp', 'gif'];
+
+      async function handleImageFile(file: File) {
+        const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+        if (!ALLOWED_EXTS.includes(ext)) {
+          showToast(
+            'Only .jpg, .jpeg, .png, .webp, .gif files can be uploaded',
+            true
+          );
+          return;
+        }
+
+        zone.classList.add('uploading');
+        zone.querySelector<HTMLElement>('.img-drop-label')!.textContent =
+          'Uploading…';
+
+        try {
+          const arrayBuf = await file.arrayBuffer();
+          const bytes = new Uint8Array(arrayBuf);
+          let binary = '';
+          for (let i = 0; i < bytes.length; i++)
+            binary += String.fromCharCode(bytes[i]);
+          const b64 = btoa(binary);
+
+          const repoPath = `site/public/media/${collection}/${file.name}`;
+          const publicPath = `/media/${collection}/${file.name}`;
+
+          await API.put(repoPath, b64, undefined, `media: upload ${file.name}`);
+
+          pathInput.value = publicPath;
+
+          const objectUrl = URL.createObjectURL(file);
+          previewImg.src = objectUrl;
+          previewEl.style.display = 'block';
+
+          showToast('Uploaded — path filled in');
+        } catch (err: unknown) {
+          showToast('Upload failed: ' + (err as Error).message, true);
+        } finally {
+          zone.classList.remove('uploading');
+          zone.querySelector<HTMLElement>('.img-drop-label')!.textContent =
+            'Drop image here or click to browse';
+        }
+      }
+
+      // Drag-and-drop
+      let dragCounter = 0;
+      zone.addEventListener('dragenter', (e) => {
+        e.preventDefault();
+        dragCounter++;
+        zone.classList.add('dragging');
+      });
+      zone.addEventListener('dragleave', () => {
+        dragCounter--;
+        if (dragCounter <= 0) {
+          dragCounter = 0;
+          zone.classList.remove('dragging');
+        }
+      });
+      zone.addEventListener('dragover', (e) => {
+        e.preventDefault();
+      });
+      zone.addEventListener('drop', (e) => {
+        e.preventDefault();
+        dragCounter = 0;
+        zone.classList.remove('dragging');
+        const file = e.dataTransfer?.files[0];
+        if (file) handleImageFile(file);
+      });
+
+      // Click-to-browse
+      zone.addEventListener('click', (e) => {
+        if ((e.target as HTMLElement).closest('.img-drop-file-input')) return;
+        fileInput.click();
+      });
+      fileInput.addEventListener('change', () => {
+        const file = fileInput.files?.[0];
+        if (file) handleImageFile(file);
+        fileInput.value = '';
+      });
+    });
+  }
+
   // ── Content buttons wiring ───────────────────────────────────────────
   function initContentButtons() {
     document.querySelectorAll('.edit-entry-btn').forEach((btn) => {
@@ -1765,7 +1937,12 @@ function fmtDate(d: Date) {
           ? (d.tags as string[]).join(', ')
           : (d.tags ?? ''),
       },
-      { name: 'image', label: 'Image path', value: d.image },
+      {
+        name: 'image',
+        label: 'Image path',
+        value: d.image,
+        uploadCollection: type === 'project' ? 'projects' : 'writing',
+      },
     ];
     if (type === 'project') {
       base.push({ name: 'link', label: 'External link (URL)', value: d.link });

--- a/site/src/pages/admin.astro
+++ b/site/src/pages/admin.astro
@@ -1688,7 +1688,13 @@ function fmtDate(d: Date) {
   async function loadMammoth(): Promise<MammothModule> {
     const w = window as Window & { mammoth?: MammothModule };
     if (w.mammoth) return w.mammoth;
-    await import('https://cdn.jsdelivr.net/npm/mammoth@1/mammoth.browser.min.js');
+    await new Promise<void>((resolve, reject) => {
+      const s = document.createElement('script');
+      s.src = 'https://cdn.jsdelivr.net/npm/mammoth@1/mammoth.browser.min.js';
+      s.onload = () => resolve();
+      s.onerror = () => reject(new Error('Failed to load mammoth.js'));
+      document.head.appendChild(s);
+    });
     return w.mammoth!;
   }
 
@@ -1804,6 +1810,11 @@ function fmtDate(d: Date) {
 
       if (!pathInput || !previewEl || !previewImg || !fileInput) return;
 
+      // Capture as non-nullable consts so TS can narrow inside async closures
+      const safePathInput = pathInput;
+      const safePreviewEl = previewEl;
+      const safePreviewImg = previewImg;
+
       const ALLOWED_EXTS = ['jpg', 'jpeg', 'png', 'webp', 'gif'];
 
       async function handleImageFile(file: File) {
@@ -1833,11 +1844,11 @@ function fmtDate(d: Date) {
 
           await API.put(repoPath, b64, undefined, `media: upload ${file.name}`);
 
-          pathInput.value = publicPath;
+          safePathInput.value = publicPath;
 
           const objectUrl = URL.createObjectURL(file);
-          previewImg.src = objectUrl;
-          previewEl.style.display = 'block';
+          safePreviewImg.src = objectUrl;
+          safePreviewEl.style.display = 'block';
 
           showToast('Uploaded — path filled in');
         } catch (err: unknown) {

--- a/site/src/pages/admin.astro
+++ b/site/src/pages/admin.astro
@@ -1349,14 +1349,16 @@ function fmtDate(d: Date) {
       path: string,
       fileContent: string,
       sha: string | undefined,
-      message: string
+      message: string,
+      base64 = false
     ): Promise<void> {
-      const body: Record<string, string> = {
+      const body: Record<string, string | boolean> = {
         path,
         content: fileContent,
         message,
       };
       if (sha) body['sha'] = sha;
+      if (base64) body['base64'] = true;
       const res = await fetch('/api/content', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -1842,7 +1844,15 @@ function fmtDate(d: Date) {
           const repoPath = `site/public/media/${collection}/${file.name}`;
           const publicPath = `/media/${collection}/${file.name}`;
 
-          await API.put(repoPath, b64, undefined, `media: upload ${file.name}`);
+          // Fetch existing SHA so overwriting a same-named file works.
+          const existing = await API.get(repoPath).catch(() => null);
+          await API.put(
+            repoPath,
+            b64,
+            existing?.sha,
+            `media: upload ${file.name}`,
+            true
+          );
 
           safePathInput.value = publicPath;
 

--- a/site/src/pages/api/content.ts
+++ b/site/src/pages/api/content.ts
@@ -105,6 +105,8 @@ export const PUT: APIRoute = async ({ request }) => {
     content: string;
     message: string;
     sha?: string;
+    /** When true, content is already base64-encoded (e.g. binary uploads). */
+    base64?: boolean;
   };
 
   if (!body.path || body.content === undefined || !body.message) {
@@ -114,8 +116,10 @@ export const PUT: APIRoute = async ({ request }) => {
     );
   }
 
-  // Base64-encode the raw file content for the GitHub API
-  const encoded = btoa(unescape(encodeURIComponent(body.content)));
+  // base64 flag: binary uploads pre-encode content; text content needs encoding here.
+  const encoded = body.base64
+    ? body.content
+    : btoa(unescape(encodeURIComponent(body.content)));
 
   const payload: Record<string, string> = {
     message: body.message,


### PR DESCRIPTION
## Summary

Closes #245. Part of Epic #241. Builds on #242 (side drawer).

- Drop zone below the **Image path** field in the project and essay editors
- Accepts `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif` via drag-and-drop or click-to-browse
- Upload flow: `FileReader.readAsArrayBuffer` → `btoa` → `PUT /api/content` with base64-encoded binary and commit message `media: upload {filename}`
- On success: image path field auto-filled with the public URL, thumbnail preview shown below the drop zone
- "Uploading…" label during the PUT; drop zone disabled to prevent concurrent uploads
- Non-image files rejected with an error toast

## Human decision recorded

> Where should uploaded images land?

**Decision:** use the existing directory structure in the repo:

| Context | Repo path | Public URL |
|---|---|---|
| Project | `site/public/media/projects/{filename}` | `/media/projects/{filename}` |
| Essay | `site/public/media/writing/{filename}` | `/media/writing/{filename}` |

Both subdirectories already exist (`ls site/public/media/` confirms `projects/` and `writing/`). Last write wins on name collision — same as content edits.

## Test plan

- [ ] Open a project editor — drop zone appears below Image path
- [ ] Drag a `.jpg` onto the drop zone — "Uploading…" shows, then path fills and thumbnail appears
- [ ] Click the drop zone — file picker opens; select an image — same result
- [ ] Drop a `.pdf` or other non-image — error toast, field unchanged
- [ ] Essay editor also has the upload drop zone
- [ ] Testimonial editor has no drop zone
- [ ] Uploaded file appears in `site/public/media/projects/` (or `writing/`) in the repo
- [ ] Build passes, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)