### PR TITLE
fix(admin): fix CSS scoping for JS-injected drawer fields + show image preview on open

### DIFF
--- a/site/src/pages/admin.astro
+++ b/site/src/pages/admin.astro
@@ -717,7 +717,7 @@ function fmtDate(d: Date) {
   <div id="toast" role="status" aria-live="polite"></div>
 </Layout>
 
-<style>
+<style is:global>
   /* ── Site map tree ──────────────────────────────────────────────────── */
   .tree {
     display: flex;
@@ -1829,6 +1829,12 @@ function fmtDate(d: Date) {
       const safePathInput = pathInput;
       const safePreviewEl = previewEl;
       const safePreviewImg = previewImg;
+
+      // Show preview immediately if the field already has an image path
+      if (safePathInput.value.trim()) {
+        safePreviewImg.src = safePathInput.value.trim();
+        safePreviewEl.style.display = '';
+      }
 
       const ALLOWED_EXTS = ['jpg', 'jpeg', 'png', 'webp', 'gif'];
 


### PR DESCRIPTION
Fixes #251

## What broke

Astro scopes `<style>` blocks by injecting a `data-astro-cid-*` attribute on
template elements and rewriting CSS selectors to match. Drawer fields are
injected via JS `innerHTML` — they never receive that attribute. Rules like
`.img-drop-file-input { opacity: 0 }` silently failed, leaving the native
browser file picker fully visible inside the image drop zone (as seen in the
screenshot in #251).

## Changes

- `<style>` → `<style is:global>` — CSS now applies to all elements regardless
  of insertion method. The admin page uses specific BEM-style class names so
  there's no bleed risk to other pages.
- `initImageUpload` now shows a preview immediately on drawer open when the
  image path field is already populated, so existing records display their
  current image rather than a blank drop zone.

## Test plan
- [ ] Open the drawer for an existing project/writing item that has an image — preview should appear immediately
- [ ] Image drop zone should show only "Drop image here or click to browse" text, with no native "Choose File | No file chosen" visible
- [ ] Dropping or clicking to browse an image still works and updates the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)