### PR TITLE
Epic 0: Lock v1 architecture decisions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,23 +8,37 @@
 | Styling | Tailwind CSS | Utility-first, no runtime CSS |
 | Content | Files in `site/src/content/` | Git-backed, CMS-editable, human-readable |
 | CMS | Pages CMS | Free, Git-backed, no database |
-| Hosting (production) | GitHub Pages | Free for public repos, deploys from `main` |
-| Hosting (preview) | Vercel | Deploys from `dev`; shows drafts before they go live |
+| Hosting | Vercel | Production and preview; required for auth/admin serverless routes |
 | Booking | Calendly embed | Configured via `bookingUrl` in Site Settings; no backend required |
+
+## Repo and package naming (locked 2026-04-28)
+
+| Item | Name | Notes |
+|------|------|-------|
+| Public engine repo | `portfolio-engine` | GitHub: `rainonej/portfolio-engine` (rename from `profesional_site`) |
+| Private consumer repo | `agreni-site` | New private repo; Agreni's actual site |
+| npm scope | `@portfolio-engine/*` | Register scope before first publish |
+| Core integration package | `@portfolio-engine/engine-core` | Astro integration, virtual modules, route registry |
+| Theme package | `@portfolio-engine/editorial-theme` | Layouts, components, styles |
+| Schema package | `@portfolio-engine/schema` | Shared Zod schemas and content types |
+| Admin tools package | `@portfolio-engine/admin-tools` | Admin UI, route inspection panels |
+| Workflow kit package | `@portfolio-engine/workflow-kit` | GitHub Actions workflow templates |
+
+See [docs/v1-non-goals.md](v1-non-goals.md) for a locked list of packages and patterns that are explicitly out of scope for v1.
 
 ## Repository layout
 
 ```text
-professional_site/
+portfolio-engine/               ← public repo (renamed from profesional_site)
   .pages.yml                  ← Pages CMS configuration
   .husky/pre-commit           ← Pre-commit hook (Prettier + ESLint on staged files)
   .github/
     workflows/
-      ci.yml                  ← Lint, check, build, deploy (GitHub Pages on main)
+      ci.yml                  ← Lint, check, build, deploy
       update-pr-branches.yml  ← Auto-updates open PRs when dev advances
       claude-agent.yml        ← Runs Claude Code Action on claude-ready issues or @claude mentions
   site/
-    astro.config.mjs          ← Base path: /profesional_site (GH Pages) or / (Vercel)
+    astro.config.mjs          ← Base path: / (Vercel only; no GitHub Pages base path)
     src/
       pages/                  ← Route files (.astro)
       components/             ← Nav, Footer, etc.
@@ -53,22 +67,30 @@ professional_site/
 
 To leave feedback or request changes, use Vercel comments on the preview site — see [docs/collaborator-walkthrough.md](collaborator-walkthrough.md).
 
-## Git / deployment flow
+## Deployment model (locked 2026-04-28)
 
-Two-branch model:
+`agreni-site` is a **private repo** and is deployed **exclusively via Vercel**. GitHub Pages is not used for `agreni-site` because:
+
+1. GitHub Pages on private repos requires a paid GitHub plan
+2. Auth and admin routes require serverless functions, which GitHub Pages cannot run regardless
+
+Vercel handles both the static HTML and the serverless routes (`/api/auth/*`, `/api/content`) from a single deployment.
+
+The `portfolio-engine` public repo may use GitHub Pages for package documentation — that is an Epic 2 decision and does not affect this deployment model.
+
+### Git / deployment flow
 
 ```text
-feat/* branch
-  → PR targeting dev
+task/* or feat/* branch
+  → PR targeting dev (or epic branch)
   → CI (lint, astro-check, build)
-  → auto-merge into dev
-    → Vercel preview rebuilds (~1 min)
+  → merge into dev
+    → Vercel auto-deploys preview (~1 min)
     → preview at https://profesional-site.vercel.app
 
 dev → main (release PR)
-  → CI + deploy
-    → GitHub Pages rebuilds (~1 min)
-    → live at https://rainonej.github.io/profesional_site/
+  → CI
+  → Vercel promotes to production
 ```
 
 When Agreni edits via Pages CMS:
@@ -77,15 +99,26 @@ When Agreni edits via Pages CMS:
 - Vercel auto-deploys the preview
 - Developer opens a `dev → main` release PR when ready to go live
 
-## Base path
+### Environment variables
 
-`astro.config.mjs` uses `process.env.GITHUB_ACTIONS === 'true'` to conditionally set the base:
+All secrets are managed in the Vercel dashboard. Key variables:
 
-- GitHub Pages build: `base: '/profesional_site'`
-- Vercel / local: `base: '/'`
+| Variable | Purpose |
+|----------|---------|
+| `GITHUB_CLIENT_ID` | GitHub OAuth app client ID |
+| `GITHUB_CLIENT_SECRET` | GitHub OAuth app client secret (server-only) |
+| `SESSION_SECRET` | HMAC key for signing session cookies (server-only) |
+| `PUBLIC_ADMIN_ORIGIN` | Override admin origin for cross-origin setups (optional) |
+| `GITHUB_CONTENT_REPO` | Target repo for the content API (`owner/repo`) — parameterized in Epic 1 |
 
-All internal links use `import.meta.env.BASE_URL` as a prefix.
+### OAuth app
+
+One OAuth app per deployment target. The production app callback URL must match the Vercel production domain. Update the `GITHUB_CONTENT_REPO` environment variable (once parameterized in Epic 1) when migrating to `agreni-site` — do not hardcode repo references in source.
 
 ## Image upload
 
 All CMS-uploaded images go to `site/public/media/` and are committed to Git. Keep filenames simple (letters, numbers, hyphens) to avoid path issues.
+
+## v1 constraints
+
+See [docs/v1-non-goals.md](v1-non-goals.md) for the full list of locked non-goals and approved packages. That document is the canonical reference for scope decisions during the `portfolio-engine` extraction (Epics 1–10).

--- a/docs/v1-non-goals.md
+++ b/docs/v1-non-goals.md
@@ -1,0 +1,55 @@
+# v1 Non-Goals
+
+_Locked: 2026-04-28. These are standing architectural constraints for the v1 `portfolio-engine` extraction. Use this document as the canonical reference when evaluating new dependencies, patterns, or feature requests._
+
+---
+
+## What we are explicitly not building in v1
+
+### No third-party theme packages
+
+- **No `astro-theme-provider`** — the engine ships its own integration layer, not a theme provider abstraction
+- **No `astro-pages`** — route management is handled directly via Astro's file-based router
+- **No `astro-public`** — packaged `public/` directory support is out of scope for v1
+
+These packages were evaluated and rejected. Do not re-open these discussions without a concrete use case that cannot be served by the approved integration helper.
+
+### No generic content patterns
+
+- **No generic content collection injection** — collections are explicit and schema-typed (projects, writing, testimonials, settings). No dynamic/arbitrary collection registration.
+- **No content collection codegen from external schemas** — schemas are hand-authored in `content.config.ts` with Zod
+
+### No multi-theme support
+
+- **No multi-theme runtime** — one theme, one site. No theme switching, no theme context providers, no `themes[]` config arrays.
+- **No theme marketplace abstractions** — the engine is not a platform for distributing arbitrary themes
+
+### No packaged `public/` directory
+
+Static assets are managed in the consumer repo (`agreni-site`), not packaged into the engine. This avoids asset path conflicts and keeps the engine footprint minimal.
+
+### No automation beyond scope
+
+- **No automatic patch cleanup in v1** — patch tracking (Epic 10) is planned, but auto-cleanup automation is explicitly deferred
+- **No Dependabot or automatic dependency update merges** — updates are human-reviewed
+
+---
+
+## What is approved
+
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| `astro-integration-kit` | Integration helper for building engine packages | The **only** approved integration helper for `engine-core` and `editorial-theme` |
+| `@astrojs/tailwind` | CSS framework integration | Already in use |
+| `@astrojs/vercel` | Serverless adapter | Required for auth/admin routes |
+| `zod` | Schema validation | Used in content collections |
+
+If `astro-integration-kit` proves unfit during Epic 3 work, document the finding and open a decision issue before substituting.
+
+---
+
+## Why this document exists
+
+Without explicit non-goals, well-intentioned contributors (human or AI) will reach for `astro-theme-provider` because it solves a real problem. The engine solves that problem differently. This document is the standing "we decided not to do this" record so the decision is not re-litigated on every PR.
+
+Reference this file in Epic 3, 4, and 7 task reviews.


### PR DESCRIPTION
## Summary

- Documents final repo names (`portfolio-engine` public, `agreni-site` private) and npm scope (`@portfolio-engine/*`) with all five package names
- Creates `docs/v1-non-goals.md` — locked list of banned packages/patterns and approved helpers for the v1 extraction; canonical reference for all Epic 1–10 scope decisions
- Updates `docs/architecture.md`: removes GitHub Pages hosting, documents Vercel-only deployment model for `agreni-site` (private repo; GitHub Pages not viable without paid plan), adds OAuth/env var guidance

## What changed

| File | Change |
|------|--------|
| `docs/architecture.md` | Repo naming table, Vercel-only deployment section, env var table, reference to v1-non-goals |
| `docs/v1-non-goals.md` | New file — locked non-goals and approved package list |

## Closes

Closes #182 — repo names documented in architecture doc
Closes #183 — non-goals committed to docs
Closes #184 — deployment model documented
Closes #171 — Epic 0 complete; unblocks Task 1.1 (#185) and the full Epic 1–10 chain

## Test plan

- [ ] Read `docs/architecture.md` — naming table, deployment section, and v1-constraints section are present and accurate
- [ ] Read `docs/v1-non-goals.md` — non-goals list is complete, approved packages table is present
- [ ] Confirm no broken links between the two docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)