### PR TITLE
task(1.4): add route registry abstraction

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"bfc4f9ff-d5b5-4902-a888-7d56cb5a0548","pid":35164,"acquiredAt":1777298193829}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"bfc4f9ff-d5b5-4902-a888-7d56cb5a0548","pid":35164,"acquiredAt":1777298193829}

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ coverage/
 # Local gh issue edit temp files
 .gh-parent-bodies/
 .gh-ci-issues/
+
+# Claude Code runtime artifacts
+.claude/scheduled_tasks.lock

--- a/site/src/lib/routes.ts
+++ b/site/src/lib/routes.ts
@@ -7,7 +7,10 @@
  */
 
 export type RouteSection = 'main' | 'content' | 'admin';
-export type RouteVisibility = 'public' | 'protected' | 'hidden';
+export type RouteVisibility =
+  | 'public' // top-level, listed in nav and publicRoutes
+  | 'hidden' // publicly accessible URL but not a primary nav destination (e.g. detail pages)
+  | 'protected'; // requires authentication
 
 export interface RouteRecord {
   /** URL pattern, using Astro file-based routing syntax */
@@ -16,7 +19,12 @@ export interface RouteRecord {
   label: string;
   /** Grouping for display and classification purposes */
   section: RouteSection;
-  /** Who can access this route */
+  /**
+   * Visibility level.
+   * - `public`: top-level route, included in nav and publicRoutes
+   * - `hidden`: accessible to anyone but not a primary nav item (e.g. [slug] detail pages)
+   * - `protected`: requires authentication
+   */
   visibility: RouteVisibility;
   /** Whether the engine can override this route's pattern at install time */
   remappable: boolean;
@@ -53,7 +61,7 @@ export const routes: RouteRecord[] = [
     pattern: '/work/[slug]',
     label: 'Work Detail',
     section: 'content',
-    visibility: 'public',
+    visibility: 'hidden',
     remappable: true,
     disableable: true,
   },
@@ -69,7 +77,7 @@ export const routes: RouteRecord[] = [
     pattern: '/writing/[slug]',
     label: 'Writing Detail',
     section: 'content',
-    visibility: 'public',
+    visibility: 'hidden',
     remappable: true,
     disableable: true,
   },

--- a/site/src/lib/routes.ts
+++ b/site/src/lib/routes.ts
@@ -1,0 +1,106 @@
+/**
+ * Route registry — single source of truth for all v1 routes.
+ *
+ * Each RouteRecord describes a page in the site. Fields are designed to
+ * support future engine extraction (Task 3.4) where the engine can remap,
+ * disable, or inject routes at install time.
+ */
+
+export type RouteSection = 'main' | 'content' | 'admin';
+export type RouteVisibility = 'public' | 'protected' | 'hidden';
+
+export interface RouteRecord {
+  /** URL pattern, using Astro file-based routing syntax */
+  pattern: string;
+  /** Human-readable label used in nav and admin views */
+  label: string;
+  /** Grouping for display and classification purposes */
+  section: RouteSection;
+  /** Who can access this route */
+  visibility: RouteVisibility;
+  /** Whether the engine can override this route's pattern at install time */
+  remappable: boolean;
+  /** Whether the engine can turn this route off entirely */
+  disableable: boolean;
+}
+
+export const routes: RouteRecord[] = [
+  {
+    pattern: '/',
+    label: 'Home',
+    section: 'main',
+    visibility: 'public',
+    remappable: false,
+    disableable: false,
+  },
+  {
+    pattern: '/about',
+    label: 'About',
+    section: 'main',
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  {
+    pattern: '/work',
+    label: 'Work',
+    section: 'content',
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  {
+    pattern: '/work/[slug]',
+    label: 'Work Detail',
+    section: 'content',
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  {
+    pattern: '/writing',
+    label: 'Writing',
+    section: 'content',
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  {
+    pattern: '/writing/[slug]',
+    label: 'Writing Detail',
+    section: 'content',
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  {
+    pattern: '/contact',
+    label: 'Contact',
+    section: 'main',
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  {
+    pattern: '/admin',
+    label: 'Admin',
+    section: 'admin',
+    visibility: 'protected',
+    remappable: false,
+    disableable: false,
+  },
+];
+
+/** All public-facing routes (excludes protected and hidden) */
+export const publicRoutes = routes.filter((r) => r.visibility === 'public');
+
+/** Routes grouped by section */
+export const routesBySection = routes.reduce<
+  Record<RouteSection, RouteRecord[]>
+>(
+  (acc, route) => {
+    acc[route.section].push(route);
+    return acc;
+  },
+  { main: [], content: [], admin: [] }
+);


### PR DESCRIPTION
## Summary

Introduces a typed TypeScript route registry — a single source of truth for all v1 routes. This is a critical-path deliverable that unblocks Epic 8 (workflow classification) and Task 3.4 (engine-core route injection).

**New module:** `site/src/lib/routes.ts`

**`RouteRecord` interface fields:**
- `pattern` — URL pattern (e.g. `/work/[slug]`)
- `label` — human-readable name
- `section` — grouping (e.g. `main`, `content`, `admin`)
- `visibility` — `public` | `protected` | `hidden`
- `remappable` — whether the engine can override the path
- `disableable` — whether the engine can turn the route off

**Registered routes:** Home, About, Work, Work detail, Writing, Writing detail, Contact, Admin

Part of Epic 1 (#172). Task 1.5 (admin site map, #189) depends on this.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)