### PR TITLE
task(1.5): replace hardcoded admin site map with route-registry-backed SiteMapTree

### DIFF
--- a/site/src/components/SiteMapTree.astro
+++ b/site/src/components/SiteMapTree.astro
@@ -1,0 +1,79 @@
+---
+import type { RouteRecord } from '../lib/routes';
+
+interface Props {
+  routes: RouteRecord[];
+}
+
+const { routes } = Astro.props;
+const currentPath = Astro.url.pathname;
+
+// Root node (/)
+const root = routes.find((r) => r.pattern === '/');
+
+// Top-level branches: routes with no dynamic segments, excluding root
+const topLevel = routes.filter(
+  (r) => r.pattern !== '/' && !r.pattern.includes('[')
+);
+
+// Returns the matching detail route ([slug] child) for a given top-level route
+function detailOf(parent: RouteRecord): RouteRecord | undefined {
+  return routes.find(
+    (r) => r.pattern.startsWith(parent.pattern + '/') && r.pattern.includes('[')
+  );
+}
+
+function isCurrent(route: RouteRecord): boolean {
+  return (
+    currentPath === route.pattern || currentPath.startsWith(route.pattern + '/')
+  );
+}
+---
+
+<div class="tree">
+  {
+    root && (
+      <a
+        href={root.pattern}
+        class:list={[
+          'tree-node tree-node-home',
+          isCurrent(root) && 'tree-node-current',
+        ]}
+      >
+        {root.pattern} — {root.label}
+      </a>
+    )
+  }
+
+  <div class="tree-stem"></div>
+
+  <div class="tree-branches">
+    {
+      topLevel.map((route) => {
+        const detail = detailOf(route);
+        return (
+          <div class="tree-branch">
+            <div class="tree-stem" />
+            <a
+              href={route.pattern}
+              class:list={[
+                'tree-node',
+                isCurrent(route) && 'tree-node-current',
+              ]}
+            >
+              {route.pattern} — {route.label}
+            </a>
+            {detail && (
+              <>
+                <div class="tree-stem" />
+                <span class="tree-node tree-node-dynamic">
+                  {detail.pattern}
+                </span>
+              </>
+            )}
+          </div>
+        );
+      })
+    }
+  </div>
+</div>

--- a/site/src/pages/admin.astro
+++ b/site/src/pages/admin.astro
@@ -1,9 +1,11 @@
 ---
 import { getCollection } from 'astro:content';
 import TestimonialBlock from '../components/TestimonialBlock.astro';
+import SiteMapTree from '../components/SiteMapTree.astro';
 import Layout from '../layouts/Layout.astro';
 import person from '../content/profile/person.json';
 import site from '../content/config/site.json';
+import { routes } from '../lib/routes';
 import { formatDate, sortByDateDesc } from '../lib/utils';
 
 // Load ALL writing including drafts for the admin view
@@ -628,47 +630,7 @@ const writingSorted = sortByDateDesc(writing);
         <div
           class="overflow-x-auto rounded-2xl border border-[var(--warm-line)] bg-[var(--paper-light)] p-8"
         >
-          <div class="tree">
-            <!-- Root -->
-            <a href="/" class="tree-node tree-node-home">/ — Home</a>
-
-            <!-- Stem -->
-            <div class="tree-stem"></div>
-
-            <!-- Level-1 branches -->
-            <div class="tree-branches">
-              <div class="tree-branch">
-                <div class="tree-stem"></div>
-                <a href="/about" class="tree-node">/about — About</a>
-              </div>
-
-              <div class="tree-branch">
-                <div class="tree-stem"></div>
-                <a href="/work" class="tree-node">/work — Work</a>
-                <div class="tree-stem"></div>
-                <span class="tree-node tree-node-dynamic">/work/[slug]</span>
-              </div>
-
-              <div class="tree-branch">
-                <div class="tree-stem"></div>
-                <a href="/writing" class="tree-node">/writing — Writing</a>
-                <div class="tree-stem"></div>
-                <span class="tree-node tree-node-dynamic">/writing/[slug]</span>
-              </div>
-
-              <div class="tree-branch">
-                <div class="tree-stem"></div>
-                <a href="/contact" class="tree-node">/contact — Contact</a>
-              </div>
-
-              <div class="tree-branch">
-                <div class="tree-stem"></div>
-                <a href="/admin" class="tree-node tree-node-current"
-                  >/admin — Admin</a
-                >
-              </div>
-            </div>
-          </div>
+          <SiteMapTree routes={routes} />
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary

- Adds `SiteMapTree.astro` — derives the admin structure tree from the route registry (`routes.ts`) rather than hand-authored markup
- Top-level branches are driven by non-dynamic routes; `[slug]` detail pages attach automatically as children of their parent
- Current-page highlight uses `Astro.url.pathname` instead of a hardcoded class
- Removes ~35 lines of hardcoded HTML from `admin.astro`

Adding or removing a route from `routes.ts` now automatically updates the admin site map with no markup changes needed.

Part of Epic 1 (#172). Depends on Task 1.4 (#188, merged).

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)