### PR TITLE
task(1.9): update .pages.yml CMS config after settings restructure

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -12,40 +12,25 @@ media:
       - gif
 
 content:
-  - name: settings
-    label: Site Settings
+  - name: person
+    label: Profile — Person
     type: file
-    path: site/src/content/settings/main.json
+    path: site/src/content/profile/person.json
     fields:
       - name: name
         label: Name
         type: string
-        description: Displayed in the nav and hero on the homepage.
-      - name: tagline
-        label: Tagline
-        type: string
-        description: Short line shown under your name on the homepage.
-      - name: bio
-        label: Bio
-        type: text
-        description: Your bio on the About page. You can use line breaks.
+        description: Displayed in the nav, hero, and page titles.
       - name: email
         label: Email
         type: string
-        description: Shown in About and Contact pages (e.g. for “Prefer email?”).
-      - name: bookingUrl
-        label: Booking URL
-        type: string
-        description: >
-          Your full Calendly (or other booking) URL, e.g.
-          https://calendly.com/yourname/30min. When set, the “Book a
-          conversation” button on the homepage and the inline booking widget on
-          the Contact page will use this link. Leave empty to hide the booking
-          widget until you're ready.
+        description: Shown on the About and Contact pages.
       - name: photo
         label: Photo
         type: image
-        description: Profile image on the About page. Upload to media; leave empty for initial-only placeholder.
+        description: >
+          Profile image on the About page and homepage hero. Upload to media;
+          leave empty for initial-only placeholder.
         options:
           media: media
       - name: linkedin
@@ -56,6 +41,92 @@ content:
         label: Instagram URL
         type: string
         description: Full URL, e.g. https://instagram.com/yourhandle. Optional.
+      - name: bio
+        label: Bio
+        type: text
+        description: Your bio on the About page and homepage. You can use line breaks.
+
+  - name: site
+    label: Profile — Site Config
+    type: file
+    path: site/src/content/config/site.json
+    fields:
+      - name: tagline
+        label: Tagline
+        type: string
+        description: Short line shown after your name on the homepage hero.
+      - name: bookingUrl
+        label: Booking URL
+        type: string
+        description: >
+          Your full Calendly (or other booking) URL, e.g.
+          https://calendly.com/yourname/30min. When set, the "Book a
+          conversation" button on the homepage and the inline booking widget on
+          the Contact page will use this link. Leave empty to hide the booking
+          widget until you're ready.
+
+  - name: navigation
+    label: Navigation
+    type: file
+    path: site/src/content/config/navigation.json
+    fields:
+      - name: links
+        label: Nav Links
+        type: object
+        list: true
+        fields:
+          - name: href
+            label: Path
+            type: string
+            description: Page path, e.g. /about or /work.
+          - name: label
+            label: Label
+            type: string
+            description: Text shown in the nav bar.
+
+  - name: features
+    label: Focus Areas
+    type: file
+    path: site/src/content/config/features.json
+    fields:
+      - name: pillars
+        label: Thematic Pillars
+        type: object
+        list: true
+        fields:
+          - name: heading
+            label: Heading
+            type: string
+            required: true
+            description: Short title for this area of focus.
+          - name: body
+            label: Description
+            type: text
+            description: One or two sentences describing this focus area.
+          - name: image
+            label: Image
+            type: image
+            description: Illustrative image for this pillar.
+            options:
+              media: media
+      - name: ctaBody
+        label: Collaboration CTA
+        type: text
+        description: Short text in the "Let's collaborate" call-to-action section at the bottom of the homepage.
+
+  - name: contact
+    label: Contact Page Copy
+    type: file
+    path: site/src/content/config/contact.json
+    fields:
+      - name: heading
+        label: Heading
+        type: string
+        description: Main heading on the contact page, e.g. "Let's work together".
+      - name: body
+        label: Body
+        type: text
+        description: Short paragraph shown under the heading on the contact page.
 
   - name: cv
     label: CV — Awards & Education
@@ -155,11 +226,11 @@ content:
         label: Date
         type: date
         required: true
-        description: Used for ordering and display (e.g. “March 2025”).
+        description: Used for ordering and display (e.g. "March 2025").
       - name: featured
         label: Show on homepage
         type: boolean
-        description: When on, this project appears in the “Featured Work” section on the homepage.
+        description: When on, this project appears in the "Featured Work" section on the homepage.
       - name: body
         label: Details
         type: rich-text


### PR DESCRIPTION
## Summary

Updates `.pages.yml` to match the file layout after Task 1.3's settings split.

**Removed:**
- `settings` entry pointing to deleted `settings/main.json`

**Added:**
- `person` → `profile/person.json` — name, email, photo, linkedin, instagram, bio
- `site` → `config/site.json` — tagline, bookingUrl
- `navigation` → `config/navigation.json` — nav links array (was previously uneditable via CMS)
- `features` → `config/features.json` — thematic pillars + CTA text (was previously uneditable via CMS)
- `contact` → `config/contact.json` — contact page heading and body (was previously uneditable via CMS)

**Unchanged:** `cv`, `projects`, `writing`, `testimonials`

Agreni can now edit all content and config through the Pages CMS with no broken fields.

Part of Epic 1 (#172). Depends on Task 1.3 (#187, merged) and Task 1.7 (#191, merged).

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)